### PR TITLE
Don't filter results based on text input

### DIFF
--- a/src/Components/GeoSearchInput/GeoSearchInput.tsx
+++ b/src/Components/GeoSearchInput/GeoSearchInput.tsx
@@ -42,6 +42,7 @@ export const GeoSearchInput: React.FC<GeoSearchInputProps> = ({ onChange }) => {
         className="geo-search"
         options={options}
         labelText="Enter your address to get started"
+        filterOption={null}
         onInputChange={(value: string) => {
           requester.changeSearchRequest(value);
           return value;


### PR DESCRIPTION
**Ticket**: https://app.shortcut.com/justfixnyc/story/15638/investigate-user-issues-with-geosearch-address-autocomplete

**Explanation**: We don't need the use the built in react-select filtering of options. We're using the geosearch api for that.

**Before**:
<img width="655" alt="image" src="https://github.com/user-attachments/assets/9a6f4f94-c604-47f6-87d1-bea13fb710b8">

**After**:
<img width="637" alt="image" src="https://github.com/user-attachments/assets/27e4530f-a97c-4b60-9b9a-837fd1d52142">
