### PR TITLE
Add mobile responsiveness

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -56,7 +56,7 @@
 }
 
 .geo-search-form {
-  width: 37rem; // 592px;
+  max-width: 37rem; // 592px;
 }
 
 .legal-header {

--- a/src/Components/Pages/ConfirmAddress/ConfirmAddress.scss
+++ b/src/Components/Pages/ConfirmAddress/ConfirmAddress.scss
@@ -7,9 +7,13 @@
   align-items: center;
   margin-top: 2.25rem; //36px
 
+  h2 {
+    text-align: center;
+  }
+
   .confirmation__subheader {
     @include body_large_desktop;
-    width: 682px;
+    max-width: 42.625rem; //682px;
     text-align: center;
   }
 
@@ -19,10 +23,10 @@
     border-radius: 16px;
     padding: 2rem; //32px
     text-align: center;
+    max-width: 40rem; //634px
 
     .img-wrapper__img {
-      width: 634px;
-      height: 352px;
+      width: 100%;
     }
   }
 

--- a/src/Components/Pages/Form/Form.scss
+++ b/src/Components/Pages/Form/Form.scss
@@ -29,7 +29,7 @@ $inputTopMargin: 1.5rem; //24px
   }
 
   #rent-input {
-    width: 19.375rem; // 310px
+    max-width: 19.375rem; // 310px
   }
 }
 

--- a/src/Components/Pages/Home/Home.scss
+++ b/src/Components/Pages/Home/Home.scss
@@ -9,7 +9,7 @@
 .main-content {
   flex-grow: 1;
   margin-top: 2.25rem; //36px
-  width: 55%;
+
   .content-p {
     @include body_large_desktop;
   }

--- a/src/Components/Pages/Results/Results.scss
+++ b/src/Components/Pages/Results/Results.scss
@@ -34,7 +34,7 @@ $resultsTableW: 1000px;
   flex-direction: column;
   margin: 2.625rem 0; //42px
   gap: 4px;
-  width: $resultsTableW + 2 * $resulsTablePadding;
+  max-width: $resultsTableW + 2 * $resulsTablePadding;
 }
 
 
@@ -42,7 +42,7 @@ $resultsTableW: 1000px;
   border-radius: 16px;
   border: 1px solid $GREY_NEW;
   padding: $resulsTablePadding;
-  width: $resultsTableW;
+  max-width: $resultsTableW;
 }
 
 .eligibility__table__header {
@@ -84,9 +84,16 @@ $resultsTableW: 1000px;
   align-items: center;
   padding: 24px 0;
 
+  @media (max-width: 772px){
+    flex-direction: column;
+    gap: 16px;
+    text-align: center;
+  }
+
   .eligibility__row__icon {
     padding: 0 2rem;
     font-size: 1.875rem; //30px
+    width: 1.875rem; //30px
 
     .eligible {
       color: $GREEN;
@@ -102,10 +109,16 @@ $resultsTableW: 1000px;
   .eligibility__row__info {
     display: flex;
     flex-direction: column;
+    flex-shrink: 0;
     width: 400px;
     padding-right: 1rem;
     box-sizing: border-box;
     gap: 10px;
+
+    @media (max-width: 772px){
+      width: 100%;
+    }
+
   }
 
   .eligibility__row__criteria {
@@ -118,12 +131,17 @@ $resultsTableW: 1000px;
 
   .eligibility__row__userValue {
     @include body_standard_desktop;
-    width: 400px;
     margin: 0 1.25rem; // 20px
     box-sizing: border-box;
+    flex-grow: 1;
+
+    @media (max-width: 772px){
+      margin: 0;
+    }
   }
   .eligibility__row__moreInfo {
     text-decoration: underline;
+    white-space: nowrap;
   }
 }
 

--- a/src/Components/RadioGroup/RadioGroup.scss
+++ b/src/Components/RadioGroup/RadioGroup.scss
@@ -2,11 +2,12 @@ $inputTopMargin: 1.5rem; //24px
 
 .radio-options {
   display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
   margin-top: $inputTopMargin;
 
   .radio-button {
     min-width: 5.625rem; // 90px
-    margin-right: 1rem;
-    margin-bottom: 0;
+    margin-right: 0;
   }
 }


### PR DESCRIPTION
Ensures basic usability on mobile. I achieved this mostly by: 
- changing `width`s to `max-width`s so that elements would shrink as the screen size got smaller.
- using `flex-wrap`
- setting a breakpoint for the results page, after which the `flex-direction` for each row on info changes to `column`.

Still requires some additional design work.

<img width="373" alt="image" src="https://github.com/user-attachments/assets/616ead54-6c2c-4cbe-8831-980f4d0df253">
<img width="369" alt="image" src="https://github.com/user-attachments/assets/a6474756-d112-41eb-98e9-a3026428c083">

<img width="376" alt="image" src="https://github.com/user-attachments/assets/082be9ed-0e98-4f9f-bf17-17e632cd37d7">

<img width="373" alt="image" src="https://github.com/user-attachments/assets/0dfafee1-e52e-4d4c-964c-b9cc215da7e9">

