### PR TITLE
A11y improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@justfixnyc/component-library": "0.51.4",
+    "@justfixnyc/component-library": "0.51.5",
     "@justfixnyc/geosearch-requester": "^1.0.3-alpha.0",
     "@rollbar/react": "^0.12.0-beta",
     "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@justfixnyc/component-library": "0.51.5",
+    "@justfixnyc/component-library": "0.51.7",
     "@justfixnyc/geosearch-requester": "^1.0.3-alpha.0",
     "@rollbar/react": "^0.12.0-beta",
     "react": "^18.3.1",

--- a/src/App.scss
+++ b/src/App.scss
@@ -62,4 +62,5 @@
 .legal-header {
   font-size: 1rem;
   font-weight: 600;
+  letter-spacing: normal;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,11 +32,11 @@ const Layout = () => {
         </h1>
       </header>
 
-      <div id="main">
+      <main id="main">
         <div id="content">
           <Outlet />
         </div>
-      </div>
+      </main>
       <ScrollRestoration />
     </div>
   );

--- a/src/Components/LegalDisclaimer/LegalDisclaimer.tsx
+++ b/src/Components/LegalDisclaimer/LegalDisclaimer.tsx
@@ -1,7 +1,7 @@
 export const LegalDisclaimer: React.FC = () => {
   return (
     <div id="legal-footer">
-      <p className="legal-header">Legal Disclaimer</p>
+      <h2 className="legal-header">Legal Disclaimer</h2>
       <p className="content-p">
         The information on this website does not constitute legal advice and
         must not be used as a substitute for the advice of a lawyer qualified to

--- a/src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx
+++ b/src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx
@@ -28,7 +28,7 @@ export const ConfirmAddress: React.FC = () => {
         learn if you're covered
       </p>
       <div className="img-wrapper">
-        <img className="img-wrapper__img" src={mapImageURL} />
+        <img className="img-wrapper__img" src={mapImageURL} alt="Map showing location of the entered address."/>
         <p className="confirmation__address">{address?.address}</p>
       </div>
       <div className="confirmation__buttons">

--- a/src/Components/Pages/Results/Results.scss
+++ b/src/Components/Pages/Results/Results.scss
@@ -60,6 +60,12 @@ $resultsTableW: 1000px;
   }
 }
 
+.eligibility__table__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
 .eligibility__table__footer {
   display: flex;
   flex-direction: column;

--- a/src/Components/Pages/Results/Results.tsx
+++ b/src/Components/Pages/Results/Results.tsx
@@ -37,7 +37,7 @@ const EligibilityIcon: React.FC<{ determination?: Determination }> = ({
 
 const CriteriaResult: React.FC<CriteriaEligibility> = (props) => {
   return (
-    <div className="eligibility__row">
+    <li className="eligibility__row">
       <span className="eligibility__row__icon">
         <EligibilityIcon determination={props?.determination} />
       </span>
@@ -52,7 +52,7 @@ const CriteriaResult: React.FC<CriteriaEligibility> = (props) => {
       </div>
       <span className="eligibility__row__userValue">{props?.userValue}</span>
       <span className="eligibility__row__moreInfo">More info</span>
-    </div>
+    </li>
   );
 };
 const CoveredPill: React.FC<{ determination: Determination }> = ({
@@ -142,24 +142,26 @@ export const Results: React.FC = () => {
             )}
           </div>
 
-          {eligibilityResults?.rent && (
-            <CriteriaResult {...eligibilityResults.rent} />
-          )}
-          {eligibilityResults?.rentRegulation && (
-            <CriteriaResult {...eligibilityResults.rentRegulation} />
-          )}
-          {eligibilityResults?.buildingClass && (
-            <CriteriaResult {...eligibilityResults.buildingClass} />
-          )}
-          {eligibilityResults?.yearBuilt && (
-            <CriteriaResult {...eligibilityResults.yearBuilt} />
-          )}
-          {eligibilityResults?.subsidy && (
-            <CriteriaResult {...eligibilityResults.subsidy} />
-          )}
-          {eligibilityResults?.portfolioSize && (
-            <CriteriaResult {...eligibilityResults.portfolioSize} />
-          )}
+          <ul className="eligibility__table__list">
+            {eligibilityResults?.rent && (
+              <CriteriaResult {...eligibilityResults.rent} />
+            )}
+            {eligibilityResults?.rentRegulation && (
+              <CriteriaResult {...eligibilityResults.rentRegulation} />
+            )}
+            {eligibilityResults?.buildingClass && (
+              <CriteriaResult {...eligibilityResults.buildingClass} />
+            )}
+            {eligibilityResults?.yearBuilt && (
+              <CriteriaResult {...eligibilityResults.yearBuilt} />
+            )}
+            {eligibilityResults?.subsidy && (
+              <CriteriaResult {...eligibilityResults.subsidy} />
+            )}
+            {eligibilityResults?.portfolioSize && (
+              <CriteriaResult {...eligibilityResults.portfolioSize} />
+            )}
+          </ul>
 
           <div className="eligibility__table__footer">
             Is something not quite right?

--- a/src/Components/Pages/Results/Results.tsx
+++ b/src/Components/Pages/Results/Results.tsx
@@ -27,11 +27,11 @@ const EligibilityIcon: React.FC<{ determination?: Determination }> = ({
 }) => {
   switch (determination) {
     case "eligible":
-      return <Icon icon="check" className={determination} />;
+      return <Icon icon="check" className={determination} title="Pass" />;
     case "ineligible":
-      return <Icon icon="ban" className={determination} />;
+      return <Icon icon="ban" className={determination} title="Fail" />;
     default:
-      return <Icon icon="circleExclamation" className="unknown" />;
+      return <Icon icon="circleExclamation" className="unknown" title="Unsure" />;
   }
 };
 

--- a/src/hooks/eligibility.tsx
+++ b/src/hooks/eligibility.tsx
@@ -55,15 +55,15 @@ function eligibilityPortfolioSize(
     if (wow_portfolio_units !== undefined && wow_portfolio_units > 10) {
       userValue = (
         <>
-          Your building has only {unitsres} apartments, but your landlord may own{" "}
-          {wow_portfolio_bbls! - 1} other buildings
+          {`Your building has only ${unitsres} apartments, but your landlord may own
+          ${wow_portfolio_bbls! - 1} other buildings`}
         </>
       );
     } else {
       userValue = (
         <>
-          Your building has only {unitsres} apartments, but your landlord may own
-          other buildings
+          {`Your building has only ${unitsres} apartments, but your landlord may own
+          other buildings`}
         </>
       );
     }
@@ -97,9 +97,9 @@ function eligibilityRent(criteriaData: CriteriaData): CriteriaEligibility {
 
   const requirement = (
     <>
-      For a {bedrooms}
-      {bedrooms !== "studio" && " bedroom"}, rent must be less than{" "}
-      {rentCutoffs[bedrooms]}
+      {`For a ${bedrooms}
+      ${bedrooms !== "studio" && " bedroom"}, rent must be less than
+      ${rentCutoffs[bedrooms]}`}
     </>
   );
   if (bedrooms === "studio") {
@@ -116,8 +116,8 @@ function eligibilityRent(criteriaData: CriteriaData): CriteriaEligibility {
 
   const userValue = (
     <>
-      Your rent is {determination === "eligible" ? "less" : "more"} than{" "}
-      {rentCutoffs[bedrooms]}.
+      {`Your rent is ${determination === "eligible" ? "less" : "more"} than
+      ${rentCutoffs[bedrooms]}.`}
     </>
   );
 
@@ -213,11 +213,11 @@ function eligibilityBuildingClass(
     bldgTypeName === "" ? (
       <>Your building is not an exempted type.</>
     ) : (
-      <>Your building is {bldgTypeName}, and is exempt.</>
+      <>{`Your building is ${bldgTypeName}, and is exempt.`}</>
     );
   const moreInfo = !!bldgclass && (
     <>
-      Your building class is {bldgclass}
+      {`Your building class is ${bldgclass}`}
     </>
   );
 
@@ -261,9 +261,9 @@ function eligibilityYearBuilt(criteriaData: CriteriaData): CriteriaEligibility {
         new Date(yearbuilt, 1, 1) >= cutoffDate ? "unknown" : "eligible";
       userValue = (
         <>
-          There is no recorded certificate of occupancy for your building since{" "}
-          {cutoffYear}, {determination === "unknown" ? "but" : "and"} other data
-          indicates it was built in {yearbuilt}.
+          {`There is no recorded certificate of occupancy for your building since
+          ${cutoffYear}, ${determination === "unknown" ? "but" : "and"} other data
+          indicates it was built in {yearbuilt}.`}
         </>
       );
     }
@@ -272,8 +272,8 @@ function eligibilityYearBuilt(criteriaData: CriteriaData): CriteriaEligibility {
     determination = coDate >= cutoffDate ? "ineligible" : "eligible";
     userValue = (
       <>
-        Your building was issued a certificate of occupancy on{" "}
-        {coDate.toLocaleDateString("en-US", dateOptions)}.
+        {`Your building was issued a certificate of occupancy on
+        ${coDate.toLocaleDateString("en-US", dateOptions)}.`}
       </>
     );
   }
@@ -300,9 +300,9 @@ function eligibilitySubsidy(criteriaData: CriteriaData): CriteriaEligibility {
     if (is_nycha || is_subsidized) {
       userValue = (
         <>
-          You don't know if you live in subsidized or public housing, but
-          available data indicates that your building is{" "}
-          {is_nycha ? "public housing" : "subsidized"}.
+          {`You don't know if you live in subsidized or public housing, but
+          available data indicates that your building is
+          ${is_nycha ? "public housing" : "subsidized"}.`}
         </>
       );
     } else {
@@ -316,7 +316,7 @@ function eligibilitySubsidy(criteriaData: CriteriaData): CriteriaEligibility {
     }
   } else if (housingType === "public" || housingType === "subsidized") {
     determination = "ineligible";
-    userValue = <>You reported that you live in {housingType} housing.</>;
+    userValue = <>{`You reported that you live in ${housingType} housing.`}</>;
   } else {
     determination = "eligible";
     userValue = (

--- a/yarn.lock
+++ b/yarn.lock
@@ -450,10 +450,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@justfixnyc/component-library@0.51.5":
-  version "0.51.5"
-  resolved "https://registry.yarnpkg.com/@justfixnyc/component-library/-/component-library-0.51.5.tgz#b32f8873ae5762b2582ee5dc47eb5817884256b2"
-  integrity sha512-Wf8ClCdXsixX/EIyrIXEoJL1uPisNcPRXVPSJhQkS1p5I7bS82AmkHJt1FiBIBrW7J8kd7l9J34spIwZNzE1iA==
+"@justfixnyc/component-library@0.51.7":
+  version "0.51.7"
+  resolved "https://registry.yarnpkg.com/@justfixnyc/component-library/-/component-library-0.51.7.tgz#d773c0c9a22e22ce774350b34e9390be2843522c"
+  integrity sha512-XSEFfy05ukep8NrNw4UnhQoTlNTsib5ZJDiR02GGvPFXo8mlWLwLLiTCAtRVIhGWwtgXGCDqJ6vdG8pynGxuhA==
   dependencies:
     "@awesome.me/kit-dd32553919" "^1.0.13"
     "@babel/runtime" "^7.12.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -450,10 +450,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@justfixnyc/component-library@0.51.4":
-  version "0.51.4"
-  resolved "https://registry.yarnpkg.com/@justfixnyc/component-library/-/component-library-0.51.4.tgz#1a2c0fe4fa3710f4ef07337e64d466075f5ef8b1"
-  integrity sha512-Ixm4quE6sAYCeQpV55RqKootl8WgfgVDB8q7kR+Y1qIO8HQKEAZSKVtXrJsmZeX8Lui6nRmFeOFGTgvuhSGoKg==
+"@justfixnyc/component-library@0.51.5":
+  version "0.51.5"
+  resolved "https://registry.yarnpkg.com/@justfixnyc/component-library/-/component-library-0.51.5.tgz#b32f8873ae5762b2582ee5dc47eb5817884256b2"
+  integrity sha512-Wf8ClCdXsixX/EIyrIXEoJL1uPisNcPRXVPSJhQkS1p5I7bS82AmkHJt1FiBIBrW7J8kd7l9J34spIwZNzE1iA==
   dependencies:
     "@awesome.me/kit-dd32553919" "^1.0.13"
     "@babel/runtime" "^7.12.5"


### PR DESCRIPTION
- Ensure proper headers.
  - Set the Legal Footer header to an h2 tag. This makes it easier for screen reader users to navigate quickly around the page.

- Ensure alt text on all images.
  - Added alt text to the map image. I debated whether to just hide this entirely for screen readers, since it's not really useful to those users. But I opted for now to just give it alt text explaining what it is. You may want to remove this later though if you feel it's not helpful.

- Ensure smooth reading of text for screen readers.
  - I converted the eligbility results to string literals. Previously, react would break each piece up into it's own text node, causing screen readers to pause at the end of each chunk. With this change, the text is read as one continuous chunk of text.
 
- Ensure icons are meaningful to screenreader users
  - I updated the component library to allow `title` props on Icon components. This was used on the results page, so that screenreaders will give the user useful information that is conveyed visually through the icons in the results.

- Ensure proper landmarks. 
  - Updated the main div to use a `main` tag.

- Ensure using list element for list content
  - Updated Results table to be a `ul` with `li`s. This gives a much better screen reader experience.