### PR TITLE
fix error on portfolio size page when acris_docs is null

### DIFF
--- a/src/Components/Pages/PortfolioSize/PortfolioSize.tsx
+++ b/src/Components/Pages/PortfolioSize/PortfolioSize.tsx
@@ -22,32 +22,39 @@ const LOOM_EMBED_URL =
 type ACRISLinksProps = {
   bbl: string;
   unitsres: number;
-  acris_docs: AcrisDocument[];
+  acris_docs: AcrisDocument[] | null;
 };
 
-export const AcrisLinks: React.FC<ACRISLinksProps> = (props) => (
-  <>
-    <ul>
-      {props.acris_docs.map((docInfo, i) => (
-        <li key={i}>
-          Document:{" "}
-          <JFCLLinkExternal href={urlAcrisDoc(docInfo.doc_id)}>
-            {`${acrisDocTypeFull(docInfo.doc_type)}`}
-          </JFCLLinkExternal>
-        </li>
-      ))}
-    </ul>
-    <JFCLLinkExternal href={urlAcrisBbl(props.bbl)}>
-      View all documents in ACRIS
-    </JFCLLinkExternal>
-  </>
-);
+export const AcrisLinks: React.FC<ACRISLinksProps> = ({ bbl, acris_docs }) => {
+  return (
+    <>
+      <ul>
+        {acris_docs &&
+          acris_docs.map((docInfo, i) => (
+            <li key={i}>
+              Document:{" "}
+              <JFCLLinkExternal href={urlAcrisDoc(docInfo.doc_id)}>
+                {acrisDocTypeFull(docInfo.doc_type)}
+              </JFCLLinkExternal>
+            </li>
+          ))}
+      </ul>
+      <JFCLLinkExternal href={urlAcrisBbl(bbl)}>
+        View all documents in ACRIS
+      </JFCLLinkExternal>
+    </>
+  );
+};
 
 export const AcrisAccordions: React.FC<BuildingEligibilityInfo> = (props) => {
   const MAX_PROPERTIES = 5;
+  // TODO: decide how to handle these cases, for now exclude. might also want to exclude if no acris_docs, but for now leave in.
+  const wowProperties = props.wow_data
+    ?.filter((bldg) => bldg.unitsres > 0)
+    .slice(0, MAX_PROPERTIES);
   return (
     <ul>
-      {props.wow_data?.slice(0, MAX_PROPERTIES).map((bldg, i) => {
+      {wowProperties?.map((bldg, i) => {
         return (
           <li key={i}>
             <details>

--- a/src/Components/Pages/Results/Results.tsx
+++ b/src/Components/Pages/Results/Results.tsx
@@ -180,14 +180,31 @@ const EligibilityNextSteps: React.FC<{
             <div className="content-box__section__header">
               We need to know if your landlord owns more than 10 units.
             </div>
-            <p>
-              {`Good Cause Eviction law only covers tenants whose landlord owns
+            {bldgData.wow_portfolio_units > bldgData.unitsres ? (
+              <>
+                <p>
+                  {`Good Cause Eviction law only covers tenants whose landlord owns
                 more than 10 units. Your building has only ${bldgData.unitsres} apartments, but
                 your landlord may own other buildings.`}
-            </p>
-            <JFCLLinkInternal to="/portfolio_size">
-              Lean how to find out
-            </JFCLLinkInternal>
+                </p>
+
+                <JFCLLinkInternal to="/portfolio_size">
+                  Lean how to find out
+                </JFCLLinkInternal>
+              </>
+            ) : (
+              <>
+                <p>
+                  {`Good Cause Eviction law only covers tenants whose landlord owns
+                more than 10 units. Your building has only ${bldgData.unitsres} apartments.`}
+                </p>
+                <br />
+                <p>
+                  We are unable to find other apartments your landlord might own
+                  in our records.
+                </p>
+              </>
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
- Sometimes we can't find any specific acris docs to link to, and we weren't checking for nulls here so it would cause and error and break the page. Now in those cases we just show the "view all documents" link to bbl search results. (will want to think through this more later)
- Also we don't show related properties if they have `0` units (need to think more about how to handle these in the wow data)
- Also, don't link out to the next step portfolio-size guide page when we don't have any related properties to display.

[sc-15838]