### PR TITLE
Cleanup page layout styles, fix mobile, add back RS helper text

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -56,12 +56,21 @@
   max-width: 37rem; // 592px;
 }
 
-.legal-header {
-  font-size: 1rem;
-  font-weight: 600;
-  letter-spacing: normal;
+#legal-footer {
+  margin-top: 1.5rem; // 24px
+  .legal-header {
+    font-size: 1rem;
+    font-weight: 600;
+    letter-spacing: normal;
+  }
 }
 
 .disabled {
   pointer-events: none;
+}
+
+.back-link.jfcl-link {
+  .jfcl-link__icon {
+    margin: 0 0.75rem 0 0; // 12px
+  }
 }

--- a/src/Components/BreadCrumbs/BreadCrumbs.scss
+++ b/src/Components/BreadCrumbs/BreadCrumbs.scss
@@ -2,14 +2,14 @@
 
 .breadCrumbs {
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
   align-items: center;
   padding: 1.5rem 0; //24px
   position: absolute;
-  width: 100%;
   top: 0;
   .breadCrumbs__crumb,
-  .breadCrumbs__last-crumb {
+  .breadCrumbs__crumb__active {
     font-size: 1.125rem; // 18px
   }
   .breadCrumbs__crumb {
@@ -19,7 +19,7 @@
       text-decoration: none;
     }
   }
-  .breadCrumbs__last-crumb {
+  .breadCrumbs__crumb__active {
     font-weight: 600;
   }
 }

--- a/src/Components/BreadCrumbs/BreadCrumbs.tsx
+++ b/src/Components/BreadCrumbs/BreadCrumbs.tsx
@@ -3,36 +3,34 @@ import { Icon } from "@justfixnyc/component-library";
 import "./BreadCrumbs.scss";
 
 interface BreadCrumbs {
-  crumbs: { path?: string; name?: string }[];
+  crumbs: { path?: string; name?: string; active?: boolean }[];
 }
 export const BreadCrumbs: React.FC<BreadCrumbs> = ({ crumbs }) => {
   const crumbpath = crumbs.flatMap((crumb, index, array) => {
+    const CrumbElement = crumb.active ? (
+      <span key={index} className="breadCrumbs__crumb__active">
+        {crumb.name}
+      </span>
+    ) : (
+      <Link
+        key={index}
+        to={crumb.path ?? "/"}
+        className="jfcl-link breadCrumbs__crumb"
+      >
+        {crumb.name}
+      </Link>
+    );
+
     if (index !== array.length - 1) {
       return [
-        <Link
-          key={index}
-          to={crumb.path ?? "/"}
-          className="jfcl-link breadCrumbs__crumb"
-        >
-          {crumb.name}
-        </Link>,
+        CrumbElement,
         <span key={index + "caret"} className="breadCrumbs__caret">
           <Icon icon="caretRight" />
         </span>,
       ];
+    } else {
+      return CrumbElement;
     }
-    return (
-      <span key={index} className="breadCrumbs__last-crumb">
-        {crumb.name}
-      </span>
-    );
   });
   return <div className="breadCrumbs">{crumbpath}</div>;
 };
-
-export const BackToResults: React.FC = () => (
-  <Link to="/results" className="jfcl-link back-to-results">
-    <Icon icon="chevronLeft" className="jfcl-link__icon" />
-    Back to coverage result
-  </Link>
-);

--- a/src/Components/ContentBox/ContentBox.scss
+++ b/src/Components/ContentBox/ContentBox.scss
@@ -1,15 +1,14 @@
 @import "../../mixins.scss";
 @import "../../colors.scss";
+@import "../../variables.scss";
 
-$contentBoxPadding: 36px;
-$contentBoxWidth: 781px;
 $contentPWidth: 677px;
 $videoEmbedW: 623px;
 
 .content-box {
-  border-radius: 4px;
+  border-radius: 8px;
   border: 2px solid $GREY_NEW;
-  width: $contentBoxWidth;
+  max-width: $contentBoxWidth;
   margin: 36px 0;
   background-color: $WHITE;
 }

--- a/src/Components/FormStep/FormStep.scss
+++ b/src/Components/FormStep/FormStep.scss
@@ -1,11 +1,11 @@
 @import "../../colors.scss";
 @import "../../mixins.scss";
-@import "../ContentBox/ContentBox.scss";
+@import "../../variables.scss";
 
 .form-step {
   border-radius: 4px;
   border: 1px solid $GREY_NEW;
-  width: $contentBoxWidth;
+  max-width: $contentBoxWidth;
   background-color: $WHITE;
 
   padding: 1.5rem; //24px

--- a/src/Components/JFCLLinkInternal.tsx
+++ b/src/Components/JFCLLinkInternal.tsx
@@ -6,16 +6,26 @@ import classNames from "classnames";
 // Creating a version of React Router's Link component styled like our Component
 // library's Internal Link.
 
-const JFCLLinkInternal: React.FC<{
+type JFCLLinkInternal = {
   to: To;
   children: React.ReactNode;
   className?: string | undefined;
-}> = (props) => {
-  return (
-    <Link to={props.to} className={classNames(props.className, "jfcl-link")}>
-      {props.children} <Icon icon="arrowRight" className="jfcl-link__icon" />
-    </Link>
-  );
 };
+
+const JFCLLinkInternal: React.FC<JFCLLinkInternal> = (props) => (
+  <Link to={props.to} className={classNames(props.className, "jfcl-link")}>
+    {props.children} <Icon icon="arrowRight" className="jfcl-link__icon" />
+  </Link>
+);
+
+export const BackLink: React.FC<JFCLLinkInternal> = (props) => (
+  <Link
+    to={props.to}
+    className={classNames(props.className, "jfcl-link back-link")}
+  >
+    <Icon icon="chevronLeft" className="jfcl-link__icon" />
+    {props.children}
+  </Link>
+);
 
 export default JFCLLinkInternal;

--- a/src/Components/Pages/ConfirmAddress/ConfirmAddress.scss
+++ b/src/Components/Pages/ConfirmAddress/ConfirmAddress.scss
@@ -1,46 +1,59 @@
 @import "../../../colors.scss";
 @import "../../../mixins.scss";
+@import "../../../variables.scss";
+
+$mapBoxPadding: 1.5rem; // 24px
+$mapImgWidth: calc($contentBoxWidth - (2 * $mapBoxPadding)); // 838px
+$mapImgHeight: 356px;
 
 .confirmation__wrapper {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  margin-top: 2.25rem; //36px
+  .headline-section {
+    background-color: $OFF_WHITE_NEW;
+    padding-bottom: 0;
 
-  h2 {
-    text-align: center;
-  }
-
-  .confirmation__subheader {
-    @include body_large_desktop;
-    max-width: 42.625rem; //682px;
-    text-align: center;
-  }
-
-  .img-wrapper {
-    display: inline-block;
-    border: 1px solid $GREY_400;
-    border-radius: 16px;
-    padding: 2rem; //32px
-    text-align: center;
-    max-width: 40rem; //634px
-
-    .img-wrapper__img {
-      width: 100%;
+    .headline-section__content {
+      // width: calc($mapImgWidth + (2 * 1.5rem));
+      .headline-section__subtitle {
+        margin-bottom: 0;
+      }
     }
   }
 
-  .confirmation__address {
-    @include body_large_desktop;
-    margin-bottom: 0;
+  .content-box {
+    padding: $mapBoxPadding;
+
+    .img-wrapper,
+    .img-wrapper__img {
+      border-radius: 4px;
+      width: 100%;
+      height: $mapImgHeight;
+    }
+    .img-wrapper {
+      background-color: $GREY_NEW;
+    }
+    .img-wrapper__img {
+      object-fit: cover;
+    }
+
+    .confirmation__address {
+      @include body_large_desktop;
+      margin: 1.5rem 0 0 0; // 24px
+      text-align: center;
+      font-size: 2.25rem; // 36px;
+      font-weight: 600;
+      line-height: 100%; // 36px;
+    }
   }
 
   .confirmation__buttons {
+    align-self: center;
     display: inline-flex;
-    margin-top: 2rem; //32px
+    margin: 0.75rem 0 1.5rem 0; // 12px 0 24px 0
 
-    .confirmation__button:first-of-type {
-      margin-right: 1rem; //16px
+    .confirmation__back {
+      margin-right: 0.625rem; //10px
+      padding: 0.75rem 1.5rem 0.75rem 0; // 12px 24px 12px 0;
+      align-self: center;
     }
   }
 }

--- a/src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx
+++ b/src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx
@@ -2,6 +2,9 @@ import { Button } from "@justfixnyc/component-library";
 import { Address } from "../Home/Home";
 import "./ConfirmAddress.scss";
 import { useLoaderData, useNavigate } from "react-router-dom";
+import { ContentBox } from "../../ContentBox/ContentBox";
+import { BackLink } from "../../JFCLLinkInternal";
+import { BreadCrumbs } from "../../BreadCrumbs/BreadCrumbs";
 
 export const ConfirmAddress: React.FC = () => {
   const navigate = useNavigate();
@@ -13,43 +16,62 @@ export const ConfirmAddress: React.FC = () => {
   const zoom = "15.25";
   const bearing = "0";
   const pitch = "0";
-  const size = "634x352";
+  const width = "814";
+  const height = "356";
+  // const size = "634x352";
   const marker = `pin-s+000(${longLat})`;
 
-  const mapImageURL = `https://api.mapbox.com/styles/v1/${styleToken}/static/${marker}/${longLat},${zoom},${bearing},${pitch}/${size}?access_token=${accessToken}`;
+  const mapImageURL = `https://api.mapbox.com/styles/v1/${styleToken}/static/${marker}/${longLat},${zoom},${bearing},${pitch}/${width}x${height}?access_token=${accessToken}`;
 
   return (
     <div className="confirmation__wrapper">
-      <h2>Confirm your address</h2>
-      <p className="confirmation__subheader">
-        We'll use info about your building from public data sources to help
-        learn if you're covered
-      </p>
-      <div className="img-wrapper">
-        <img
-          className="img-wrapper__img"
-          src={mapImageURL}
-          alt="Map showing location of the entered address."
-        />
-        <p className="confirmation__address">{address.address}</p>
+      <div className="headline-section">
+        <div className="headline-section__content">
+          <BreadCrumbs
+            crumbs={[
+              { path: "/home", name: "Home" },
+              {
+                path: "/confirm_address",
+                name: address?.address || "Your address",
+              },
+              { path: "/form", name: "Screener survey" },
+              { path: "/results", name: "Coverage result" },
+            ]}
+          />
+
+          <h2 className="headline-section__title">Confirm your address</h2>
+          <div className="headline-section__subtitle">
+            We'll use info about your building from public data sources to help
+            learn if you're covered
+          </div>
+        </div>
       </div>
-      <div className="confirmation__buttons">
-        <Button
-          className="confirmation__button"
-          labelText="Back"
-          labelIcon="chevronLeft"
-          variant="secondary"
-          onClick={() => {
-            navigate("/home");
-          }}
-        />
-        <Button
-          className="confirmation__button"
-          labelText="Next"
-          onClick={() => {
-            navigate("/form");
-          }}
-        />
+
+      <div className="content-section">
+        <div className="content-section__content">
+          <ContentBox>
+            <div className="img-wrapper">
+              <img
+                className="img-wrapper__img"
+                src={mapImageURL}
+                alt="Map showing location of the entered address."
+              />
+            </div>
+            <h3 className="confirmation__address">{address.address}</h3>
+          </ContentBox>
+          <div className="confirmation__buttons">
+            <BackLink to="/home" className="confirmation__back">
+              Back
+            </BackLink>
+            <Button
+              className="confirmation__button"
+              labelText="Next"
+              onClick={() => {
+                navigate("/form");
+              }}
+            />
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/Components/Pages/Form/Form.scss
+++ b/src/Components/Pages/Form/Form.scss
@@ -1,6 +1,6 @@
 @import "../../../mixins.scss";
 @import "../../../colors.scss";
-@import "../../ContentBox/ContentBox.scss";
+@import "../../../variables.scss";
 
 $inputTopMargin: 1.5rem; //24px
 

--- a/src/Components/Pages/Form/Form.tsx
+++ b/src/Components/Pages/Form/Form.tsx
@@ -57,20 +57,19 @@ export const Form: React.FC = () => {
     setLocalFields(updatedFields as FormFields);
   };
 
-  // TODO: temporarily disabled for this round of playbook ux testing
-  // const rsHelperText = !bldgData
-  //   ? undefined
-  //   : bldgData.unitsres > 0 && bldgData.post_hstpa_rs_units >= bldgData.unitsres
-  //   ? "Our data shows that all apartments in your building are registered as rent stabilized."
-  //   : new Date(bldgData.end_421a) > new Date()
-  //   ? "Your building appears to receive the 421a tax exemption. This means your apartment is rent stabilized."
-  //   : new Date(bldgData.end_j51) > new Date()
-  //   ? "Your building appears to receive the J51 tax exemption. This means your apartment is rent stabilized."
-  //   : bldgData.post_hstpa_rs_units > 0
-  //   ? "Our data shows that some apartments in your building are registered as rent stabilized."
-  //   : bldgData.yearbuilt < 1974 && bldgData.unitsres >= 6
-  //   ? "Based on the size and age of your building, your apartment might be rent stabilized."
-  //   : undefined;
+  const rsHelperText = !bldgData
+    ? undefined
+    : bldgData.unitsres > 0 && bldgData.post_hstpa_rs_units >= bldgData.unitsres
+    ? "Our data shows that all apartments in your building are registered as rent stabilized."
+    : new Date(bldgData.end_421a) > new Date()
+    ? "Your building appears to receive the 421a tax exemption. This means your apartment is rent stabilized."
+    : new Date(bldgData.end_j51) > new Date()
+    ? "Your building appears to receive the J51 tax exemption. This means your apartment is rent stabilized."
+    : bldgData.post_hstpa_rs_units > 0
+    ? "Our data shows that some apartments in your building are registered as rent stabilized."
+    : bldgData.yearbuilt < 1974 && bldgData.unitsres >= 6
+    ? "Based on the size and age of your building, your apartment might be rent stabilized."
+    : undefined;
 
   const subsidyHelperText = !bldgData
     ? undefined
@@ -154,7 +153,7 @@ export const Form: React.FC = () => {
           <FormStep step={4} total={5}>
             <FormGroup
               legendText="Is your apartment rent-stabilized?"
-              // helperText={rsHelperText}
+              helperText={rsHelperText}
             >
               <RadioGroup
                 fields={localFields}

--- a/src/Components/Pages/Form/Form.tsx
+++ b/src/Components/Pages/Form/Form.tsx
@@ -91,7 +91,8 @@ export const Form: React.FC = () => {
               path: "/confirm_address",
               name: address?.address || "Your address",
             },
-            { path: "/form", name: "Screener survey" },
+            { path: "/form", name: "Screener survey", active: true },
+            { path: "/results", name: "Coverage result" },
           ]}
         />
 

--- a/src/Components/Pages/PortfolioSize/PortfolioSize.tsx
+++ b/src/Components/Pages/PortfolioSize/PortfolioSize.tsx
@@ -4,10 +4,10 @@ import { Icon } from "@justfixnyc/component-library";
 
 import { Address } from "../Home/Home";
 import { LegalDisclaimer } from "../../LegalDisclaimer/LegalDisclaimer";
-import { BackToResults } from "../../BreadCrumbs/BreadCrumbs";
 import { ContentBox } from "../../ContentBox/ContentBox";
 import { FormFields } from "../../../App";
 import JFCLLinkExternal from "../../JFCLLinkExternal";
+import { BackLink } from "../../JFCLLinkInternal";
 import { useGetBuildingEligibilityInfo } from "../../../api/hooks";
 import {
   AcrisDocument,
@@ -104,7 +104,7 @@ export const PortfolioSize: React.FC = () => {
     <div className="portfolios-size__wrapper">
       <div className="headline-section">
         <div className="headline-section__content">
-          <BackToResults />
+          <BackLink to="/results">Back to Coverage Result</BackLink>
           {error && (
             <div className="eligibility__error">
               There was an error loading your results, please try again in a few
@@ -218,7 +218,7 @@ export const PortfolioSize: React.FC = () => {
           </div>
         </ContentBox>
         <div className="eligibility__footer">
-          <BackToResults />
+          <BackLink to="/results">Back to coverage result</BackLink>
         </div>
         <LegalDisclaimer />
       </div>

--- a/src/Components/Pages/RentStabilization/RentStabilization.tsx
+++ b/src/Components/Pages/RentStabilization/RentStabilization.tsx
@@ -4,7 +4,7 @@ import { Button } from "@justfixnyc/component-library";
 import { LegalDisclaimer } from "../../LegalDisclaimer/LegalDisclaimer";
 import { ContentBox } from "../../ContentBox/ContentBox";
 import JFCLLinkExternal from "../../JFCLLinkExternal";
-import { BackToResults } from "../../BreadCrumbs/BreadCrumbs";
+import { BackLink } from "../../JFCLLinkInternal";
 import "./RentStabilization.scss";
 
 export const RentStabilization: React.FC = () => {
@@ -14,7 +14,7 @@ export const RentStabilization: React.FC = () => {
     <div className="rent-stabilization__wrapper">
       <div className="headline-section">
         <div className="headline-section__content">
-          <BackToResults />
+          <BackLink to="/results">Back to coverage result</BackLink>
           <div className="headline-section__page-type">Guide</div>
           <h2 className="headline-section__title">
             Find out if your apartment is rent stabilized
@@ -120,7 +120,7 @@ export const RentStabilization: React.FC = () => {
           </div>
         </ContentBox>
         <div className="eligibility__footer">
-          <BackToResults />
+          <BackLink to="/results">Back to coverage result</BackLink>
         </div>
         <LegalDisclaimer />
       </div>

--- a/src/Components/Pages/Results/Results.scss
+++ b/src/Components/Pages/Results/Results.scss
@@ -1,7 +1,7 @@
 @import "../../../mixins.scss";
 @import "../../../colors.scss";
+@import "../../../variables.scss";
 @import "../content-page.scss";
-@import "../../ContentBox/ContentBox.scss";
 
 $eligibilityTablePaddingH: 36px;
 
@@ -168,5 +168,6 @@ $eligibilityTablePaddingH: 36px;
   .eligibility__footer__header {
     @include h3_desktop;
     margin: 0 0 $eligibilityTablePaddingH 0;
+    text-align: center;
   }
 }

--- a/src/Components/Pages/content-page.scss
+++ b/src/Components/Pages/content-page.scss
@@ -1,16 +1,21 @@
 @import "../../mixins.scss";
 @import "../../colors.scss";
+@import "../../variables.scss";
 
 $eligibilityTablePaddingH: 36px;
-$contentBoxWidth: 781px;
 
 .headline-section,
 .content-section {
   display: flex;
   flex-direction: column;
   align-items: center;
+
   padding-left: 3rem; // 48px
   padding-right: 3rem; // 48px
+  @media (max-width: 772px) {
+    padding-left: 1.5rem; // 24px
+    padding-right: 1.5rem; // 24px
+  }
 }
 
 .headline-section {
@@ -20,7 +25,10 @@ $contentBoxWidth: 781px;
   background-color: $OFF_WHITE_200;
 
   .headline-section__content {
-    width: $contentBoxWidth;
+    max-width: $contentBoxWidth;
+    @media (max-width: 772px) {
+      width: 100%;
+    }
     .headline-section__page-type {
       @include eyebrow_large_desktop;
       padding-top: 30px;
@@ -31,8 +39,6 @@ $contentBoxWidth: 781px;
       flex-direction: column;
       margin: 2.625rem 0; //42px
       gap: 4px;
-      max-width: calc($contentBoxWidth + 50px);
-      width: max-content;
     }
 
     .headline-section__subtitle {
@@ -44,4 +50,10 @@ $contentBoxWidth: 781px;
 
 .content-section {
   background-color: $OFF_WHITE_NEW;
+
+  .content-section__content {
+    max-width: $contentBoxWidth;
+    display: flex;
+    flex-direction: column;
+  }
 }

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -1,1 +1,3 @@
 $headerH: 3.25rem; // 52px
+$contentBoxPadding: 36px;
+$contentBoxWidth: calc(886px - (2 * $contentBoxPadding));


### PR DESCRIPTION
- Clean up styles, particularly for the confirm address page
- Fix a few things with page layout that broke mobile version
- Add back in RS status helper text on form (disabled for testing)
- Fix breadcrumbs to show future steps, wrap on mobile (temp fix pending designs)

[sc-15843]
[sc-15841]
[sc-15834]