### PR TITLE
add bbl document link for Staten Island properties

### DIFF
--- a/src/Components/Pages/PortfolioSize/PortfolioSize.tsx
+++ b/src/Components/Pages/PortfolioSize/PortfolioSize.tsx
@@ -13,7 +13,12 @@ import {
   AcrisDocument,
   BuildingEligibilityInfo,
 } from "../../../types/APIDataTypes";
-import { acrisDocTypeFull, urlAcrisBbl, urlAcrisDoc } from "../../../helpers";
+import {
+  acrisDocTypeFull,
+  urlAcrisBbl,
+  urlAcrisDoc,
+  urlCountyClerkBbl,
+} from "../../../helpers";
 import "./PortfolioSize.scss";
 
 const LOOM_EMBED_URL =
@@ -26,11 +31,12 @@ type ACRISLinksProps = {
 };
 
 export const AcrisLinks: React.FC<ACRISLinksProps> = ({ bbl, acris_docs }) => {
+  const isStatenIsland = bbl[0] === "5";
   return (
     <>
-      <ul>
-        {acris_docs &&
-          acris_docs.map((docInfo, i) => (
+      {acris_docs && (
+        <ul>
+          {acris_docs.map((docInfo, i) => (
             <li key={i}>
               Document:{" "}
               <JFCLLinkExternal href={urlAcrisDoc(docInfo.doc_id)}>
@@ -38,10 +44,17 @@ export const AcrisLinks: React.FC<ACRISLinksProps> = ({ bbl, acris_docs }) => {
               </JFCLLinkExternal>
             </li>
           ))}
-      </ul>
-      <JFCLLinkExternal href={urlAcrisBbl(bbl)}>
-        View all documents in ACRIS
-      </JFCLLinkExternal>
+        </ul>
+      )}
+      {isStatenIsland ? (
+        <JFCLLinkExternal href={urlCountyClerkBbl(bbl)}>
+          View all documents from Richmond County Clerk
+        </JFCLLinkExternal>
+      ) : (
+        <JFCLLinkExternal href={urlAcrisBbl(bbl)}>
+          View all documents in ACRIS
+        </JFCLLinkExternal>
+      )}
     </>
   );
 };

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -76,6 +76,11 @@ export const prioritizeBldgs = (a: WowBuildings, b: WowBuildings) => {
   return b.distance_ft - a.distance_ft;
 };
 
+export const urlCountyClerkBbl = (bbl: string) => {
+  const { block, lot } = splitBBL(bbl);
+  return `https://www.richmondcountyclerk.com/Search/ShowResultsBlocks/0?Block=${block}&Lot=8${lot}`;
+};
+
 export const urlAcrisBbl = (bbl: string) => {
   const { boro, block, lot } = splitBBL(bbl);
   return `http://a836-acris.nyc.gov/bblsearch/bblsearch.asp?borough=${boro}&block=${block}&lot=${lot}`;


### PR DESCRIPTION
Adds links to BBL search results on Staten Island's ACRIS equivalent website (Richmond County Clerk)

[sc-15846]