### PR TITLE
Clear form fields on new search & data api cal on confirm page

### DIFF
--- a/src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx
+++ b/src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx
@@ -5,10 +5,12 @@ import { useLoaderData, useNavigate } from "react-router-dom";
 import { ContentBox } from "../../ContentBox/ContentBox";
 import { BackLink } from "../../JFCLLinkInternal";
 import { BreadCrumbs } from "../../BreadCrumbs/BreadCrumbs";
+import { useGetBuildingEligibilityInfo } from "../../../api/hooks";
 
 export const ConfirmAddress: React.FC = () => {
   const navigate = useNavigate();
   const { address } = useLoaderData() as { address: Address };
+  useGetBuildingEligibilityInfo(address.bbl);
 
   const styleToken = import.meta.env.VITE_MAPBOX_STYLE_TOKEN;
   const accessToken = import.meta.env.VITE_MAPBOX_ACCESS_TOKEN;
@@ -59,6 +61,7 @@ export const ConfirmAddress: React.FC = () => {
             </div>
             <h3 className="confirmation__address">{address.address}</h3>
           </ContentBox>
+
           <div className="confirmation__buttons">
             <BackLink to="/home" className="confirmation__back">
               Back
@@ -67,7 +70,7 @@ export const ConfirmAddress: React.FC = () => {
               className="confirmation__button"
               labelText="Next"
               onClick={() => {
-                navigate("/form");
+                navigate("form");
               }}
             />
           </div>

--- a/src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx
+++ b/src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx
@@ -70,7 +70,7 @@ export const ConfirmAddress: React.FC = () => {
               className="confirmation__button"
               labelText="Next"
               onClick={() => {
-                navigate("form");
+                navigate("/form");
               }}
             />
           </div>

--- a/src/Components/Pages/Home/Home.tsx
+++ b/src/Components/Pages/Home/Home.tsx
@@ -5,6 +5,7 @@ import { GeoSearchInput } from "../../GeoSearchInput/GeoSearchInput";
 import { LegalDisclaimer } from "../../LegalDisclaimer/LegalDisclaimer";
 import { useSessionStorage } from "../../../hooks/useSessionStorage";
 import "./Home.scss";
+import { FormFields } from "../../../App";
 
 export type Address = {
   bbl: string;
@@ -15,6 +16,7 @@ export type Address = {
 export const Home: React.FC = () => {
   const navigate = useNavigate();
   const [address, setAddress] = useSessionStorage<Address>("address");
+  const [, , removeFormFields] = useSessionStorage<FormFields>("fields");
   const [geoAddress, setGeoAddress] = useState<Address>();
 
   return (
@@ -38,6 +40,7 @@ export const Home: React.FC = () => {
               if (geoAddress) {
                 setAddress(geoAddress);
               }
+              removeFormFields();
               navigate("confirm_address");
             }}
           />

--- a/src/Components/Pages/PortfolioSize/PortfolioSize.tsx
+++ b/src/Components/Pages/PortfolioSize/PortfolioSize.tsx
@@ -24,71 +24,6 @@ import "./PortfolioSize.scss";
 const LOOM_EMBED_URL =
   "https://www.loom.com/embed/cef3632773a14617a0e8ec407c77e513?sid=93a986f7-ccdc-4048-903c-974fed826119";
 
-type ACRISLinksProps = {
-  bbl: string;
-  unitsres: number;
-  acris_docs: AcrisDocument[] | null;
-};
-
-export const AcrisLinks: React.FC<ACRISLinksProps> = ({ bbl, acris_docs }) => {
-  const isStatenIsland = bbl[0] === "5";
-  return (
-    <>
-      {acris_docs && (
-        <ul>
-          {acris_docs.map((docInfo, i) => (
-            <li key={i}>
-              Document:{" "}
-              <JFCLLinkExternal href={urlAcrisDoc(docInfo.doc_id)}>
-                {`${acrisDocTypeFull(
-                  docInfo.doc_type
-                )} (${docInfo.doc_date.slice(0, 4)})`}
-              </JFCLLinkExternal>
-            </li>
-          ))}
-        </ul>
-      )}
-      {isStatenIsland ? (
-        <JFCLLinkExternal href={urlCountyClerkBbl(bbl)}>
-          View all documents from Richmond County Clerk
-        </JFCLLinkExternal>
-      ) : (
-        <JFCLLinkExternal href={urlAcrisBbl(bbl)}>
-          View all documents in ACRIS
-        </JFCLLinkExternal>
-      )}
-    </>
-  );
-};
-
-export const AcrisAccordions: React.FC<BuildingEligibilityInfo> = (props) => {
-  const MAX_PROPERTIES = 5;
-  // TODO: decide how to handle these cases, for now exclude. might also want to exclude if no acris_docs, but for now leave in.
-  const wowProperties = props.wow_data
-    ?.filter((bldg) => bldg.unitsres > 0)
-    .slice(0, MAX_PROPERTIES);
-  return (
-    <ul>
-      {wowProperties?.map((bldg, i) => {
-        return (
-          <li key={i}>
-            <details>
-              <summary>
-                {bldg.addr}
-                <span className="apartments-pill">{`${bldg.unitsres} apartments`}</span>
-                <Icon icon="chevronDown" className="chevron-icon" />
-              </summary>
-              <div className="content-box__section__acris-links">
-                <AcrisLinks {...bldg} />
-              </div>
-            </details>
-          </li>
-        );
-      })}
-    </ul>
-  );
-};
-
 export const PortfolioSize: React.FC = () => {
   const { address, fields } = useLoaderData() as {
     address: Address;
@@ -238,5 +173,70 @@ export const PortfolioSize: React.FC = () => {
         <LegalDisclaimer />
       </div>
     </div>
+  );
+};
+
+type ACRISLinksProps = {
+  bbl: string;
+  unitsres: number;
+  acris_docs: AcrisDocument[] | null;
+};
+
+export const AcrisLinks: React.FC<ACRISLinksProps> = ({ bbl, acris_docs }) => {
+  const isStatenIsland = bbl[0] === "5";
+  return (
+    <>
+      {acris_docs && (
+        <ul>
+          {acris_docs.map((docInfo, i) => (
+            <li key={i}>
+              Document:{" "}
+              <JFCLLinkExternal href={urlAcrisDoc(docInfo.doc_id)}>
+                {`${acrisDocTypeFull(
+                  docInfo.doc_type
+                )} (${docInfo.doc_date.slice(0, 4)})`}
+              </JFCLLinkExternal>
+            </li>
+          ))}
+        </ul>
+      )}
+      {isStatenIsland ? (
+        <JFCLLinkExternal href={urlCountyClerkBbl(bbl)}>
+          View all documents from Richmond County Clerk
+        </JFCLLinkExternal>
+      ) : (
+        <JFCLLinkExternal href={urlAcrisBbl(bbl)}>
+          View all documents in ACRIS
+        </JFCLLinkExternal>
+      )}
+    </>
+  );
+};
+
+export const AcrisAccordions: React.FC<BuildingEligibilityInfo> = (props) => {
+  const MAX_PROPERTIES = 5;
+  // TODO: decide how to handle these cases, for now exclude. might also want to exclude if no acris_docs, but for now leave in.
+  const wowProperties = props.wow_data
+    ?.filter((bldg) => bldg.unitsres > 0)
+    .slice(0, MAX_PROPERTIES);
+  return (
+    <ul>
+      {wowProperties?.map((bldg, i) => {
+        return (
+          <li key={i}>
+            <details>
+              <summary>
+                {bldg.addr}
+                <span className="apartments-pill">{`${bldg.unitsres} apartments`}</span>
+                <Icon icon="chevronDown" className="chevron-icon" />
+              </summary>
+              <div className="content-box__section__acris-links">
+                <AcrisLinks {...bldg} />
+              </div>
+            </details>
+          </li>
+        );
+      })}
+    </ul>
   );
 };

--- a/src/hooks/useSessionStorage.tsx
+++ b/src/hooks/useSessionStorage.tsx
@@ -3,7 +3,7 @@ import React from "react";
 export const useSessionStorage = <T,>(
   keyName: string,
   defaultValue?: T
-): [T | undefined, (newValue: T) => void] => {
+): [T | undefined, (newValue: T) => void, () => void] => {
   const [storedValue, setStoredValue] = React.useState<T | undefined>(() => {
     try {
       const value = window.sessionStorage.getItem(keyName);
@@ -27,5 +27,13 @@ export const useSessionStorage = <T,>(
     }
   };
 
-  return [storedValue, setValue];
+  const removeValue = (): void => {
+    try {
+      window.sessionStorage.removeItem(keyName);
+    } catch (error) {
+      window.console.error(error);
+    }
+  };
+
+  return [storedValue, setValue, removeValue];
 };


### PR DESCRIPTION
- clear form fields from session state when a new address is searched
- call the WOW api for bbl on confirm address page (one step earlier).
  - this will limit delay on helper text since it will be cached already
  - later we'll want to add a warning on the confirm_address page when there are no residential units
- also just reorder the code for results and portfolio page files for readability

[sc-15858]