### PR TITLE
remove layout flicker for map image

### DIFF
--- a/src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx
+++ b/src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx
@@ -55,6 +55,8 @@ export const ConfirmAddress: React.FC = () => {
                 className="img-wrapper__img"
                 src={mapImageURL}
                 alt="Map showing location of the entered address."
+                width={width}
+                height={height}
               />
             </div>
             <h3 className="confirmation__address">{address.address}</h3>


### PR DESCRIPTION
add W and H to <img/> to remove prevent layout flicker for the map image on confirm address page

[sc-15897]