### PR TITLE
rename gce api data for clarity

### DIFF
--- a/src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx
+++ b/src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx
@@ -5,12 +5,12 @@ import { useLoaderData, useNavigate } from "react-router-dom";
 import { ContentBox } from "../../ContentBox/ContentBox";
 import { BackLink } from "../../JFCLLinkInternal";
 import { BreadCrumbs } from "../../BreadCrumbs/BreadCrumbs";
-import { useGetBuildingEligibilityInfo } from "../../../api/hooks";
+import { useGetBuildingData } from "../../../api/hooks";
 
 export const ConfirmAddress: React.FC = () => {
   const navigate = useNavigate();
   const { address } = useLoaderData() as { address: Address };
-  useGetBuildingEligibilityInfo(address.bbl);
+  useGetBuildingData(address.bbl);
 
   const styleToken = import.meta.env.VITE_MAPBOX_STYLE_TOKEN;
   const accessToken = import.meta.env.VITE_MAPBOX_ACCESS_TOKEN;

--- a/src/Components/Pages/Form/Form.tsx
+++ b/src/Components/Pages/Form/Form.tsx
@@ -4,7 +4,7 @@ import { useLoaderData, useNavigate } from "react-router";
 
 import { FormStep } from "../../FormStep/FormStep";
 import { Address } from "../Home/Home";
-import { useGetBuildingEligibilityInfo } from "../../../api/hooks";
+import { useGetBuildingData } from "../../../api/hooks";
 import { useSessionStorage } from "../../../hooks/useSessionStorage";
 import { RadioGroup } from "../../RadioGroup/RadioGroup";
 import { FormFields } from "../../../App";
@@ -28,7 +28,7 @@ export const Form: React.FC = () => {
 
   const bbl = address.bbl;
 
-  const { data: bldgData } = useGetBuildingEligibilityInfo(bbl);
+  const { data: bldgData } = useGetBuildingData(bbl);
 
   const navigate = useNavigate();
 

--- a/src/Components/Pages/PortfolioSize/PortfolioSize.tsx
+++ b/src/Components/Pages/PortfolioSize/PortfolioSize.tsx
@@ -8,10 +8,10 @@ import { ContentBox } from "../../ContentBox/ContentBox";
 import { FormFields } from "../../../App";
 import JFCLLinkExternal from "../../JFCLLinkExternal";
 import { BackLink } from "../../JFCLLinkInternal";
-import { useGetBuildingEligibilityInfo } from "../../../api/hooks";
+import { useGetBuildingData } from "../../../api/hooks";
 import {
   AcrisDocument,
-  BuildingEligibilityInfo,
+  BuildingData,
 } from "../../../types/APIDataTypes";
 import {
   acrisDocTypeFull,
@@ -48,7 +48,7 @@ export const PortfolioSize: React.FC = () => {
     data: bldgData,
     isLoading,
     error,
-  } = useGetBuildingEligibilityInfo(bbl);
+  } = useGetBuildingData(bbl);
 
   return (
     <div className="portfolios-size__wrapper">
@@ -213,7 +213,7 @@ export const AcrisLinks: React.FC<ACRISLinksProps> = ({ bbl, acris_docs }) => {
   );
 };
 
-export const AcrisAccordions: React.FC<BuildingEligibilityInfo> = (props) => {
+export const AcrisAccordions: React.FC<BuildingData> = (props) => {
   const MAX_PROPERTIES = 5;
   // TODO: decide how to handle these cases, for now exclude. might also want to exclude if no acris_docs, but for now leave in.
   const wowProperties = props.wow_data

--- a/src/Components/Pages/Results/Results.tsx
+++ b/src/Components/Pages/Results/Results.tsx
@@ -8,8 +8,8 @@ import {
 import { Button, Icon } from "@justfixnyc/component-library";
 import classNames from "classnames";
 
-import { useGetBuildingEligibilityInfo } from "../../../api/hooks";
-import { BuildingEligibilityInfo } from "../../../types/APIDataTypes";
+import { useGetBuildingData } from "../../../api/hooks";
+import { BuildingData } from "../../../types/APIDataTypes";
 import { FormFields } from "../../../App";
 import {
   CriteriaEligibility,
@@ -54,7 +54,7 @@ export const Results: React.FC = () => {
     data: bldgData,
     isLoading,
     error,
-  } = useGetBuildingEligibilityInfo(bbl);
+  } = useGetBuildingData(bbl);
 
   const eligibilityResults = useEligibility(fields, bldgData);
 
@@ -257,7 +257,7 @@ const EligibilityCriteriaTable: React.FC<{
 );
 
 const EligibilityNextSteps: React.FC<{
-  bldgData: BuildingEligibilityInfo;
+  bldgData: BuildingData;
   eligibilityResults: EligibilityResults;
   navigate: NavigateFunction;
 }> = ({ bldgData, eligibilityResults, navigate }) => {

--- a/src/api/hooks.ts
+++ b/src/api/hooks.ts
@@ -1,14 +1,14 @@
 import useSWR from "swr";
-import { BuildingEligibilityInfo } from "../types/APIDataTypes";
+import { BuildingData } from "../types/APIDataTypes";
 import { apiFetcher } from "./helpers";
 
 type BuildingInfoSWRResponse = {
-  data: BuildingEligibilityInfo | undefined;
+  data: BuildingData | undefined;
   isLoading: boolean;
   error: Error | undefined;
 };
 
-export function useGetBuildingEligibilityInfo(
+export function useGetBuildingData(
   bbl: string
 ): BuildingInfoSWRResponse {
   const { data, error, isLoading } = useSWR(

--- a/src/hooks/eligibility.tsx
+++ b/src/hooks/eligibility.tsx
@@ -1,5 +1,5 @@
 import { FormFields } from "../App";
-import { BuildingEligibilityInfo } from "../types/APIDataTypes";
+import { BuildingData } from "../types/APIDataTypes";
 
 type Criteria =
   | "portfolioSize"
@@ -9,7 +9,7 @@ type Criteria =
   | "rentRegulation"
   | "yearBuilt";
 
-type CriteriaData = FormFields & BuildingEligibilityInfo;
+type CriteriaData = FormFields & BuildingData;
 
 export type Determination = "eligible" | "ineligible" | "unknown";
 
@@ -312,7 +312,7 @@ function eligibilitySubsidy(criteriaData: CriteriaData): CriteriaEligibility {
 
 export function useEligibility(
   formFields: FormFields,
-  bldgData?: BuildingEligibilityInfo
+  bldgData?: BuildingData
 ): EligibilityResults | undefined {
   if (!bldgData) return undefined;
   const criteriaData: CriteriaData = { ...formFields, ...bldgData };

--- a/src/types/APIDataTypes.ts
+++ b/src/types/APIDataTypes.ts
@@ -22,7 +22,7 @@ export type WowBuildings = {
   acris_docs: AcrisDocument[];
 };
 
-export type BuildingEligibilityInfo = {
+export type BuildingData = {
   bbl: string;
   unitsres: number;
   wow_portfolio_units: number;


### PR DESCRIPTION
Renames the WOW/NYCDB api data for the building. The old name included "eligibility" and became confusing now that it's not actually eligibility data but the datapoints needed to determine eligibility, and the logic is handled in a hook that was similarly named. 