### PR TITLE
first pass at styling the printable/downloadable results page

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -21,6 +21,10 @@
   text-wrap: nowrap;
   z-index: 100;
 
+  @media print {
+    display: none;
+  }
+
   h1 {
     color: $OFF_WHITE_100;
     font-size: 1.25rem; // 20px

--- a/src/Components/BreadCrumbs/BreadCrumbs.scss
+++ b/src/Components/BreadCrumbs/BreadCrumbs.scss
@@ -8,6 +8,11 @@
   padding: 1.5rem 0; //24px
   position: absolute;
   top: 0;
+
+  @media print {
+    display: none;
+  }
+
   .breadCrumbs__crumb,
   .breadCrumbs__crumb__active {
     font-size: 1.125rem; // 18px

--- a/src/Components/Pages/RentStabilization/RentStabilization.tsx
+++ b/src/Components/Pages/RentStabilization/RentStabilization.tsx
@@ -86,9 +86,7 @@ export const RentStabilization: React.FC = () => {
                 has never been rent stabilized, and therefore you meet the rent
                 regulation criteria for Good Cause Eviction.
               </p>
-              <JFCLLinkExternal
-                href="https://portal.hcr.ny.gov/app/ask"
-              >
+              <JFCLLinkExternal href="https://portal.hcr.ny.gov/app/ask">
                 Fill out the form
               </JFCLLinkExternal>
             </div>

--- a/src/Components/Pages/Results/Results.scss
+++ b/src/Components/Pages/Results/Results.scss
@@ -33,12 +33,9 @@ $eligibilityTablePaddingH: 36px;
   }
 }
 
-.eligibility__result {
-  display: flex;
-  flex-direction: column;
-  margin: 2.625rem 0; //42px
-  gap: 4px;
-  max-width: $contentBoxWidth;
+.covered-underline {
+  text-decoration: underline;
+  color: $OFF_BLACK;
 }
 
 .eligibility__toggle {
@@ -51,12 +48,22 @@ $eligibilityTablePaddingH: 36px;
   }
 }
 
-.eligibility__table {
-  border-radius: 4px;
-  border: 2px solid $GREY_NEW;
-  padding: 1.5rem $eligibilityTablePaddingH; // 24px __
-  max-width: $contentBoxWidth - (2 * $eligibilityTablePaddingH);
-  background-color: $WHITE;
+@media screen {
+  .eligibility__result__print {
+    display: none;
+  }
+
+  .eligibility__table__container__print {
+    display: none;
+  }
+
+  .eligibility__table {
+    border-radius: 4px;
+    border: 2px solid $GREY_NEW;
+    padding: 1.5rem $eligibilityTablePaddingH; // 24px __
+    max-width: $contentBoxWidth - (2 * $eligibilityTablePaddingH);
+    background-color: $WHITE;
+  }
 }
 
 .eligibility__table__header {
@@ -174,5 +181,119 @@ $eligibilityTablePaddingH: 36px;
     @include h3_desktop;
     margin: 0 0 $eligibilityTablePaddingH 0;
     text-align: center;
+  }
+}
+
+@media print {
+  .eligibility__result {
+    display: none;
+  }
+
+  .eligibility__table__container {
+    display: none;
+  }
+
+  .eligibility__table__container__print {
+    .eligibility__table {
+      border-top: 2px solid $GREY_NEW;
+      background-color: $WHITE;
+    }
+
+    .eligibility__table__header {
+      display: flex;
+      padding-bottom: $eligibilityTablePaddingH;
+      flex-direction: column;
+      gap: 10px;
+
+      .eligibility__table__header-title {
+        @include eyebrow_small_desktop;
+      }
+
+      .eligibility__table__header-subtitle {
+        @include h3_desktop;
+      }
+    }
+
+    .eligibility__table__list {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .eligibility__table__footer {
+      display: none;
+      //display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: $eligibilityTablePaddingH 0 0;
+      @include body_large_desktop;
+
+      .eligibility__table__footer__link {
+        @include body_standard_desktop;
+        margin-top: 0.625rem; //10px
+      }
+
+      a {
+        color: black;
+        margin-left: 0.625rem; //10px
+      }
+    }
+
+    .eligibility__row {
+      display: flex;
+      border-bottom: 1px solid $GREY_NEW;
+      align-items: center;
+      flex-direction: row;
+      text-align: left;
+
+      .eligibility__row__icon {
+        padding: 0 1.25rem; // 0 20px
+        font-size: 1.875rem; //30px
+        width: 1.875rem; //30px
+
+        .eligible {
+          color: $OFF_BLACK;
+        }
+        .ineligible {
+          color: $OFF_BLACK;
+        }
+        .unknown {
+          color: $OFF_BLACK;
+        }
+      }
+
+      .eligibility__row__info {
+        display: flex;
+        flex-direction: column;
+        flex-shrink: 0;
+        width: 320px;
+        padding-right: 1rem;
+        box-sizing: border-box;
+        gap: 10px;
+      }
+
+      .eligibility__row__criteria {
+        @include eyebrow_small_desktop;
+      }
+
+      .eligibility__row__requirement {
+        @include body_standard_desktop;
+      }
+
+      .eligibility__row__userValue {
+        @include body_standard_desktop;
+        margin: 0 1.25rem; // 20px
+        box-sizing: border-box;
+        flex-grow: 1;
+
+        p {
+          margin: 0 0 0.625rem 0;
+        }
+
+        .jfcl-link {
+          display: none;
+        }
+      }
+    }
   }
 }

--- a/src/Components/Pages/Results/Results.tsx
+++ b/src/Components/Pages/Results/Results.tsx
@@ -95,10 +95,14 @@ export const Results: React.FC = () => {
             ]}
           />
           <div className="headline-section__page-type">Coverage Result</div>
+          <div className="headline-section__page-type__print">
+            Good Cause Eviction Screener
+          </div>
           {bldgData && eligibilityResults && (
             <>
               <h2 className="headline-section__title">
                 <EligibilityResultHeadline
+                  address={address?.address}
                   determination={determination}
                   eligibilityResults={eligibilityResults}
                 />
@@ -122,11 +126,24 @@ export const Results: React.FC = () => {
                   showTable ? "open" : "closed"
                 )}
               />
-              {showTable && bldgData && (
-                <EligibilityCriteriaTable
-                  eligibilityResults={eligibilityResults}
-                />
-              )}
+              <div className="eligibility__table__container">
+                {showTable && bldgData && (
+                  <EligibilityCriteriaTable
+                    eligibilityResults={eligibilityResults}
+                  />
+                )}
+              </div>
+
+              <div className="eligibility__table__container__print">
+                <ContentBox
+                  headerTitle="Your results"
+                  headerSubtitle="Coverage criteria"
+                >
+                  <EligibilityCriteriaTable
+                    eligibilityResults={eligibilityResults}
+                  />
+                </ContentBox>
+              </div>
             </>
           )}
         </div>
@@ -234,17 +251,18 @@ const CriteriaResult: React.FC<CriteriaEligibility> = (props) => {
   );
 };
 
-const CoveredPill: React.FC<{ determination: Determination }> = ({
-  determination,
-}) => {
-  const className = `covered-pill covered-pill--${determination}`;
+const CoveredPill: React.FC<{
+  determination: Determination;
+  className: string;
+}> = ({ determination, className }) => {
+  const longClassName = `${className} ${className}--${determination}`;
 
   if (determination === "eligible") {
-    return <span className={className}>covered</span>;
+    return <span className={longClassName}>covered</span>;
   } else if (determination === "ineligible") {
-    return <span className={className}>not covered</span>;
+    return <span className={longClassName}>not covered</span>;
   } else {
-    return <span className={className}>might be covered</span>;
+    return <span className={longClassName}>might be covered</span>;
   }
 };
 
@@ -319,7 +337,7 @@ const EligibilityNextSteps: React.FC<{
               rent regulation status.
             </p>
             <JFCLLinkInternal to="/rent_stabilization">
-              Lean how to find out
+              Learn how to find out
             </JFCLLinkInternal>
           </div>
         </div>
@@ -343,7 +361,7 @@ const EligibilityNextSteps: React.FC<{
                 </p>
 
                 <JFCLLinkInternal to="/portfolio_size">
-                  Lean how to find out
+                  Learn how to find out
                 </JFCLLinkInternal>
               </>
             ) : (
@@ -648,14 +666,23 @@ const universalProtections = (
 );
 
 const EligibilityResultHeadline: React.FC<{
+  address: string;
   determination: Determination;
   eligibilityResults: EligibilityResults;
-}> = ({ determination, eligibilityResults }) => {
+}> = ({ address, determination, eligibilityResults }) => {
   if (determination === "unknown") {
     return (
       <>
-        <span>
-          Your apartment <CoveredPill determination={determination} />
+        <span className="eligibility__result">
+          Your apartment{" "}
+          <CoveredPill determination={determination} className="covered-pill" />
+        </span>
+        <span className="eligibility__result__print">
+          {address}{" "}
+          <CoveredPill
+            determination={determination}
+            className="covered-underline"
+          />
         </span>
         <span>by Good Cause Eviction Law</span>
       </>
@@ -663,8 +690,16 @@ const EligibilityResultHeadline: React.FC<{
   } else if (determination === "eligible") {
     return (
       <>
-        <span>
-          Your apartment is <CoveredPill determination={determination} />
+        <span className="eligibility__result">
+          Your apartment is{" "}
+          <CoveredPill determination={determination} className="covered-pill" />
+        </span>
+        <span className="eligibility__result__print">
+          {address} is{" "}
+          <CoveredPill
+            determination={determination}
+            className="covered-underline"
+          />
         </span>
         <span>by Good Cause Eviction law</span>
       </>
@@ -672,9 +707,16 @@ const EligibilityResultHeadline: React.FC<{
   } else if (eligibilityResults.rentRegulation.determination === "ineligible") {
     return (
       <>
-        <span>
+        <span className="eligibility__result">
           Your apartment is not covered by Good Cause Eviction law but{" "}
           <span className="covered-pill covered-pill--eligible">
+            you’re protected
+          </span>{" "}
+          by rent stabilization laws
+        </span>
+        <span className="eligibility__result__print">
+          {address} is not covered by Good Cause Eviction law but{" "}
+          <span className="covered-underline covered-underline--eligible">
             you’re protected
           </span>{" "}
           by rent stabilization laws
@@ -684,8 +726,16 @@ const EligibilityResultHeadline: React.FC<{
   } else if (determination === "ineligible") {
     return (
       <>
-        <span>
-          Your apartment is <CoveredPill determination={determination} />{" "}
+        <span className="eligibility__result">
+          Your apartment is{" "}
+          <CoveredPill determination={determination} className="covered-pill" />{" "}
+        </span>
+        <span className="eligibility__result__print">
+          {address} is{" "}
+          <CoveredPill
+            determination={determination}
+            className="covered-underline"
+          />
         </span>
         <span>by Good Cause Eviction law</span>
       </>

--- a/src/Components/Pages/content-page.scss
+++ b/src/Components/Pages/content-page.scss
@@ -32,6 +32,15 @@ $eligibilityTablePaddingH: 36px;
     .headline-section__page-type {
       @include eyebrow_large_desktop;
       padding-top: 30px;
+      @media print {
+        display: none;
+      }
+    }
+    .headline-section__page-type__print {
+      @include eyebrow_large_desktop;
+      @media screen {
+        display: none;
+      }
     }
 
     .headline-section__title {
@@ -39,11 +48,23 @@ $eligibilityTablePaddingH: 36px;
       flex-direction: column;
       margin: 2.625rem 0; //42px
       gap: 4px;
+      @media print {
+        margin: 24px 0;
+      }
     }
 
     .headline-section__subtitle {
       @include body_large_desktop;
       margin-bottom: 2.25rem; // 36px
+      @media print {
+        margin-bottom: 0;
+      }
+    }
+
+    .jfcl-button {
+      @media print {
+        display: none;
+      }
     }
   }
 }


### PR DESCRIPTION
this is what it looks like so far! not 1-1 with current mocks, but the content layout, table, and header capture the general gist of the mock. the Figma mock is a WIP, so more changes to come.

<img width="516" alt="Screenshot 2024-12-03 at 5 29 16 PM" src="https://github.com/user-attachments/assets/7183f930-d292-434e-a612-078332330330">
<img width="518" alt="Screenshot 2024-12-03 at 5 29 27 PM" src="https://github.com/user-attachments/assets/584a7a78-b58a-4444-95a8-41d8de8fdfeb">
