### PR TITLE
use accordions for all content box sections

### DIFF
--- a/src/Components/Accordion/Accordion.scss
+++ b/src/Components/Accordion/Accordion.scss
@@ -6,8 +6,6 @@
     display: flex;
     align-items: center;
     list-style: none;
-    @include body_standard_desktop;
-    font-weight: 600;
     cursor: pointer;
 
     .accordion__chevron {
@@ -16,7 +14,6 @@
   }
 
   &[open] {
-    padding-bottom: 1.125rem; // 18px
     summary .accordion__chevron {
       transform: scale(-1, -1);
     }

--- a/src/Components/Accordion/Accordion.scss
+++ b/src/Components/Accordion/Accordion.scss
@@ -2,6 +2,7 @@
 @import "../../mixins.scss";
 
 .accordion {
+  padding: 0;
   summary {
     display: flex;
     align-items: center;

--- a/src/Components/ContentBox/ContentBox.scss
+++ b/src/Components/ContentBox/ContentBox.scss
@@ -35,19 +35,26 @@ $videoEmbedW: 623px;
   padding: 1.5rem 2.25rem; // 24px 36px
   border-top: 1px solid $GREY_NEW;
 
+  .accordion__summary {
+    padding: 1.5rem 2.25rem; // 24px 36px
+  }
+
+  &.accordion[open] .accordion__summary {
+    padding: 1.5rem 2.25rem 1.125rem 2.25rem; // 24px 36px 18px 36px
+  }
+
   .content-box__section__header {
     @include body_large_desktop;
   }
 
   .accordion__content {
-    margin-top: 1.125rem; // 18px
+    padding: 0 2.25rem 2rem 2.25rem; // 0 36px 32px 36px
   }
 
   .content-box__section__content,
   .accordion__content {
     display: flex;
     flex-direction: column;
-    width: 100%;
 
     .content-box__section__step {
       @include eyebrow_small_desktop;
@@ -86,10 +93,6 @@ $videoEmbedW: 623px;
       }
     }
   }
-}
-
-.accordion.content-box__section[open] {
-  padding-bottom: 2rem; // 32px
 }
 
 .content-box__footer {

--- a/src/Components/ContentBox/ContentBox.scss
+++ b/src/Components/ContentBox/ContentBox.scss
@@ -35,22 +35,6 @@ $videoEmbedW: 623px;
   padding: 1.5rem 2.25rem; // 24px 36px
   border-top: 1px solid $GREY_NEW;
 
-  .eligibility__icon {
-    font-size: 1.875rem; //30px
-    width: 1.875rem; //30px
-    margin-right: 36px;
-
-    .eligible {
-      color: $GREEN;
-    }
-    .ineligible {
-      color: $RED;
-    }
-    .unknown {
-      color: $YELLOW;
-    }
-  }
-
   .content-box__section__header {
     @include body_large_desktop;
   }

--- a/src/Components/ContentBox/ContentBox.scss
+++ b/src/Components/ContentBox/ContentBox.scss
@@ -31,7 +31,8 @@ $videoEmbedW: 623px;
 .content-box__section,
 .content-box__footer {
   display: flex;
-  padding: $contentBoxPadding;
+  flex-direction: column;
+  padding: 1.5rem 2.25rem; // 24px 36px
   border-top: 1px solid $GREY_NEW;
 
   .eligibility__icon {
@@ -50,7 +51,16 @@ $videoEmbedW: 623px;
     }
   }
 
-  .content-box__section__content {
+  .content-box__section__header {
+    @include body_large_desktop;
+  }
+
+  .accordion__content {
+    margin-top: 1.125rem; // 18px
+  }
+
+  .content-box__section__content,
+  .accordion__content {
     display: flex;
     flex-direction: column;
     width: 100%;
@@ -92,6 +102,10 @@ $videoEmbedW: 623px;
       }
     }
   }
+}
+
+.accordion.content-box__section[open] {
+  padding-bottom: 2rem; // 32px
 }
 
 .content-box__footer {

--- a/src/Components/ContentBox/ContentBox.tsx
+++ b/src/Components/ContentBox/ContentBox.tsx
@@ -1,29 +1,28 @@
 import { ReactNode } from "react";
 import "./ContentBox.scss";
+import { Accordion } from "../Accordion/Accordion";
 
 export type ContentBoxProps = {
-  headerTitle?: ReactNode;
-  headerSubtitle?: ReactNode;
+  title?: ReactNode;
+  subtitle?: ReactNode;
   children: ReactNode;
 };
 
 export const ContentBox: React.FC<ContentBoxProps> = ({
-  headerTitle,
-  headerSubtitle,
+  title,
+  subtitle,
   children,
 }) => {
-  //   const arrayChildren = Children.toArray(children);
   return (
     <div className="content-box">
-      {headerTitle && (
+      {title && (
         <div className="content-box__header">
-          <div className="content-box__header-title">{headerTitle}</div>
-          {headerSubtitle && (
-            <div className="content-box__header-subtitle">{headerSubtitle}</div>
+          <div className="content-box__header-title">{title}</div>
+          {subtitle && (
+            <div className="content-box__header-subtitle">{subtitle}</div>
           )}
         </div>
       )}
-      {/* {Children.map(arrayChildren, (child, index) => {})} */}
       {children}
     </div>
   );
@@ -34,21 +33,35 @@ export type ContentBoxItemProps = {
   step?: number;
   icon?: ReactNode;
   children?: ReactNode;
+  accordion?: boolean;
+  open?: boolean;
 };
 
 export const ContentBoxItem: React.FC<ContentBoxItemProps> = ({
   title,
-  step,
   icon,
+  accordion = true,
+  open = false,
   children,
 }) => {
-  return (
-    <div className="content-box__section">
+  const headerSection = (
+    <>
       {icon && <span className="eligibility__icon">{icon}</span>}
-      {step && (
-        <div className="content-box__section__step">{`step ${step}`}</div>
-      )}
       {title && <div className="content-box__section__header">{title}</div>}
+    </>
+  );
+
+  return accordion ? (
+    <Accordion
+      summary={headerSection}
+      className="content-box__section"
+      open={open}
+    >
+      {children}
+    </Accordion>
+  ) : (
+    <div className="content-box__section">
+      {headerSection}
       {children}
     </div>
   );

--- a/src/Components/ContentBox/ContentBox.tsx
+++ b/src/Components/ContentBox/ContentBox.tsx
@@ -1,20 +1,23 @@
 import { ReactNode } from "react";
 import "./ContentBox.scss";
 import { Accordion } from "../Accordion/Accordion";
+import classNames from "classnames";
 
 export type ContentBoxProps = {
   title?: ReactNode;
   subtitle?: ReactNode;
+  className?: string;
   children: ReactNode;
 };
 
 export const ContentBox: React.FC<ContentBoxProps> = ({
   title,
   subtitle,
+  className,
   children,
 }) => {
   return (
-    <div className="content-box">
+    <div className={classNames("content-box", className)}>
       {title && (
         <div className="content-box__header">
           <div className="content-box__header-title">{title}</div>
@@ -35,6 +38,7 @@ export type ContentBoxItemProps = {
   children?: ReactNode;
   accordion?: boolean;
   open?: boolean;
+  className?: string;
 };
 
 export const ContentBoxItem: React.FC<ContentBoxItemProps> = ({
@@ -42,25 +46,24 @@ export const ContentBoxItem: React.FC<ContentBoxItemProps> = ({
   icon,
   accordion = true,
   open = false,
+  className,
   children,
 }) => {
   const headerSection = (
     <>
-      {icon && <span className="eligibility__icon">{icon}</span>}
+      {icon}
       {title && <div className="content-box__section__header">{title}</div>}
     </>
   );
 
+  const containerClass = classNames("content-box__section", className);
+
   return accordion ? (
-    <Accordion
-      summary={headerSection}
-      className="content-box__section"
-      open={open}
-    >
+    <Accordion summary={headerSection} className={containerClass} open={open}>
       {children}
     </Accordion>
   ) : (
-    <div className="content-box__section">
+    <div className={containerClass}>
       {headerSection}
       {children}
     </div>

--- a/src/Components/KYRContent/KYRContent.tsx
+++ b/src/Components/KYRContent/KYRContent.tsx
@@ -1,0 +1,232 @@
+import React from "react";
+import {
+  ContentBox,
+  ContentBoxItem,
+  ContentBoxProps,
+} from "../ContentBox/ContentBox";
+import JFCLLinkExternal from "../JFCLLinkExternal";
+import { Button } from "@justfixnyc/component-library";
+
+type ContentBoxHeaderProps = Omit<ContentBoxProps, "children">;
+
+export const UniversalProtections: React.FC<ContentBoxHeaderProps> = ({
+  title = "UNIVERSAL TENANT RIGHTS",
+  subtitle: headerSubtitle = "Protections that all New Yorkers have",
+}) => (
+  <ContentBox title={title} subtitle={headerSubtitle}>
+    <ContentBoxItem title="Your eviction protections">
+      <p>
+        The only way your landlord can evict you is through housing court.
+        Lockouts (also known as unlawful evictions or self-help evictions) are
+        illegal. All tenants, including those in private residential programs,
+        have the right to stay in their home unless they choose to leave or are
+        evicted through a court process.
+      </p>
+      <br />
+      <p className="bold">Learn more about the eviction process</p>
+      <JFCLLinkExternal
+        href="https://hcr.ny.gov/eviction"
+        className="has-label"
+      >
+        NY Homes and Community Renewal
+      </JFCLLinkExternal>
+      <br />
+      <br />
+      <p className="bold">See if you are eligible for a free attorney</p>
+      <JFCLLinkExternal
+        href="https://www.evictionfreenyc.org"
+        className="has-label"
+      >
+        Eviction Free NYC
+      </JFCLLinkExternal>
+    </ContentBoxItem>
+
+    <ContentBoxItem title="Your right to a liveable home">
+      <p>
+        Tenants have the right to live in a safe, sanitary, and well-maintained
+        apartment, including public areas of the building. This right is implied
+        in every residential lease, and any lease provision that waives it is
+        void. If your landlord is not providing these conditions in your
+        apartment or building, there are actions you can take to exercise your
+        rights.
+      </p>
+      <br />
+      <p className="bold">Learn about warranty of habitability</p>
+      <JFCLLinkExternal
+        href="https://nycourts.gov/courts/nyc/housing/pdfs/warrantyofhabitability.pdf"
+        className="has-label"
+      >
+        NY Courts
+      </JFCLLinkExternal>
+      <br />
+      <br />
+      <p className="bold">Learn how tenant associations can help</p>
+      <JFCLLinkExternal
+        href="https://www.metcouncilonhousing.org/help-answers/forming-a-tenants-association"
+        className="has-label"
+      >
+        Met Council on Housing
+      </JFCLLinkExternal>
+      <br />
+      <br />
+      <p className="bold">Notify your landlord of repair issues</p>
+      <JFCLLinkExternal
+        href="https://app.justfix.org/loc/splash"
+        className="has-label"
+      >
+        JustFix’s Letter of Complaint
+      </JFCLLinkExternal>
+    </ContentBoxItem>
+    <ContentBoxItem title="Your rights if you’re being discriminated against">
+      <p>
+        Your landlord can’t evict you based on your race, religion, gender,
+        national origin, familial status, or disability. New York State law
+        promises protection from discrimination, banning bias based on age,
+        sexual orientation, and military status.
+      </p>
+      <p>
+        Source of income discrimination the illegal practice by landlords,
+        owners, and real estate brokers of refusing to rent to current or
+        prospective tenants seeking to pay for housing with housing assistance
+        vouchers, subsidies, or other forms of public assistance.
+      </p>
+      <br />
+      <p className="bold">Learn more about fair housing</p>
+      <JFCLLinkExternal
+        href="https://www.nyc.gov/site/fairhousing/about/what-is-fair-housing.page"
+        className="has-label"
+      >
+        Fair Housing NYC
+      </JFCLLinkExternal>
+      <br />
+      <br />
+      <p className="bold">
+        Learn more about lawful source of income discrimination
+      </p>
+      <JFCLLinkExternal
+        href="https://www.nyc.gov/site/fairhousing/renters/lawful-source-of-income.page"
+        className="has-label"
+      >
+        Lawful source of income
+      </JFCLLinkExternal>
+      <br />
+      <br />
+      <p className="bold">Report source of income discrimination</p>
+      <JFCLLinkExternal href="https://weunlock.nyc" className="has-label">
+        Unlock NYC
+      </JFCLLinkExternal>
+    </ContentBoxItem>
+  </ContentBox>
+);
+
+export const GoodCauseProtections: React.FC<ContentBoxHeaderProps> = ({
+  title = "KNOW YOUR RIGHTS",
+  subtitle = "Protections you have under Good Cause Eviction law",
+}) => (
+  <ContentBox title={title} subtitle={subtitle}>
+    <ContentBoxItem title="Your right to a lease renewal">
+      <p>
+        Your landlord will need to provide a good cause reason for ending a
+        tenancy. This includes evicting tenants, not renewing a lease, or, if
+        the tenant does not have a lease, giving notice that the tenancy will
+        end.
+      </p>
+    </ContentBoxItem>
+
+    <ContentBoxItem title="Your right to limited rent increases">
+      <p>
+        Your landlord is not allowed to increase your rent at a rate higher than
+        the local standard. The local rent standard is set every year at the
+        rate of inflation plus 5%, with a maximum of 10% total.
+      </p>
+      <br />
+      <p>
+        As of May 1, 2024, the rate of inflation for the New York City area is
+        3.82%, meaning that the current local rent standard is 8.82%. A rent
+        increase of more than 8.82% could be found unreasonable by the court if
+        the rent was increased after April 20, 2024.
+      </p>
+    </ContentBoxItem>
+
+    <ContentBoxItem title="Learn more about Good Cause Eviction Law protections">
+      <JFCLLinkExternal href="https://housingjusticeforall.org/kyr-good-cause">
+        Housing Justice for All Good Cause Eviction fact sheet
+      </JFCLLinkExternal>
+      <JFCLLinkExternal
+        href="https://www.metcouncilonhousing.org/help-answers/good-cause-eviction"
+        className="has-label"
+      >
+        Met Council on Housing Good Cause Eviction fact sheet
+      </JFCLLinkExternal>
+    </ContentBoxItem>
+  </ContentBox>
+);
+
+export const GoodCauseExercisingRights: React.FC<ContentBoxHeaderProps> = ({
+  title = "EXERCISING YOUR RIGHTS",
+  subtitle: headerSubtitle = "Share your coverage with your landlord",
+}) => (
+  <ContentBox title={title} subtitle={headerSubtitle}>
+    <div className="content-box__section">
+      <div className="content-box__section__content">
+        <p>
+          Assert your rights by printing your coverage results and sharing with
+          your landlord. You can use these results as an indicator that your
+          apartment is covered by Good Cause Eviction Law.
+        </p>
+      </div>
+    </div>
+
+    <div className="content-box__footer">
+      <div className="content-box__section__content">
+        <Button
+          labelText="Print my coverage results"
+          labelIcon="print"
+          variant="secondary"
+          className="disabled"
+        />
+      </div>
+    </div>
+  </ContentBox>
+);
+
+export const RentStabilizedProtections: React.FC<ContentBoxHeaderProps> = ({
+  title = "EXERCISING YOUR RIGHTS",
+  subtitle = "Your right to limited rent increases",
+}) => (
+  <ContentBox title={title} subtitle={subtitle}>
+    <ContentBoxItem title="Your right to limited rent increases">
+      <p>
+        For rent-stabilized leases being renewed between October 1, 2024 and
+        September 30, 2025 the legal rent may be increased at the following
+        levels: for a one-year renewal there is a 2.75% increase, or for a
+        two-year renewal there is a 5.25% increase.
+      </p>
+      <JFCLLinkExternal href="https://hcr.ny.gov/system/files/documents/2024/10/fact-sheet-26-10-2024.pdf">
+        Learn about rent increase rights
+      </JFCLLinkExternal>
+    </ContentBoxItem>
+
+    <ContentBoxItem title="Your right to a lease renewal">
+      <p>
+        If you are rent-stabilized your landlord cannot simply decide they don’t
+        want you as a tenant anymore, they are limited to certain reasons for
+        evicting you.
+      </p>
+      <JFCLLinkExternal href="https://rentguidelinesboard.cityofnewyork.us/resources/faqs/leases-renewal-vacancy/#landlord:~:text=If%20your%20apartment%20is%20rent,before%20the%20existing%20lease%20expires">
+        Learn about lease renewal rights
+      </JFCLLinkExternal>
+    </ContentBoxItem>
+
+    <ContentBoxItem title="Your right to succession">
+      <p>
+        If you are the immediate family member of a rent-stabilized tenant and
+        have been living with them immediately prior to their moving or passing
+        away, you might be entitled to take over the lease.
+      </p>
+      <JFCLLinkExternal href="https://www.metcouncilonhousing.org/help-answers/succession-rights-in-rent-stabilized-and-rent-controlled-apartments/">
+        Learn about succession rights
+      </JFCLLinkExternal>
+    </ContentBoxItem>
+  </ContentBox>
+);

--- a/src/Components/Pages/PortfolioSize/PortfolioSize.scss
+++ b/src/Components/Pages/PortfolioSize/PortfolioSize.scss
@@ -23,9 +23,6 @@
     }
 
     .acris-links__content {
-      .info-box {
-        margin: 1.125rem 0; // 18px
-      }
       p {
         font-weight: 600;
         margin-top: 1.875rem; // 30px
@@ -45,6 +42,10 @@
   .content-box__section__search-building,
   .content-box__section__related-buildings {
     margin-top: 1.875rem; //30px
+  }
+
+  .content-box__section__search-building .acris-links__content .info-box {
+    margin-top: 1.125rem; // 18px
   }
 
   .content-box__section__related-buildings {

--- a/src/Components/Pages/PortfolioSize/PortfolioSize.scss
+++ b/src/Components/Pages/PortfolioSize/PortfolioSize.scss
@@ -8,7 +8,12 @@
 
   .acris-links {
     border: 1px solid $GREY_NEW;
-    padding: 1.125rem 1.5rem; // 18px 24px
+
+    .accordion__summary,
+    & > .acris-links__header {
+      padding: 1.125rem 1.5rem; // 18px 24px
+    }
+
     .acris-links__header {
       display: flex;
       align-items: center;
@@ -22,7 +27,13 @@
       }
     }
 
+    .accordion__content {
+      padding: 0;
+    }
+
     .acris-links__content {
+      padding: 0 1.5rem 1.125rem 1.5rem; // 0 24px 18px 24px
+
       p {
         font-weight: 600;
         margin-top: 1.875rem; // 30px
@@ -42,10 +53,6 @@
   .content-box__section__search-building,
   .content-box__section__related-buildings {
     margin-top: 1.875rem; //30px
-  }
-
-  .content-box__section__search-building .acris-links__content .info-box {
-    margin-top: 1.125rem; // 18px
   }
 
   .content-box__section__related-buildings {

--- a/src/Components/Pages/PortfolioSize/PortfolioSize.tsx
+++ b/src/Components/Pages/PortfolioSize/PortfolioSize.tsx
@@ -69,8 +69,8 @@ export const PortfolioSize: React.FC = () => {
       <div className="content-section">
         <div className="content-section__content"></div>
         <ContentBox
-          headerTitle="Why you need to know"
-          headerSubtitle="Good Cause Eviction covers tenants whose landlords own more than 10 apartments"
+          title="Why you need to know"
+          subtitle="Good Cause Eviction covers tenants whose landlords own more than 10 apartments"
         >
           <div className="content-box__section">
             <div className="content-box__section__content">
@@ -85,8 +85,8 @@ export const PortfolioSize: React.FC = () => {
         </ContentBox>
 
         <ContentBox
-          headerTitle="WHAT YOU CAN DO"
-          headerSubtitle="How to find other apartments your landlord owns"
+          title="WHAT YOU CAN DO"
+          subtitle="How to find other apartments your landlord owns"
         >
           <div className="content-box__section">
             <div className="content-box__section__content">

--- a/src/Components/Pages/RentStabilization/RentStabilization.tsx
+++ b/src/Components/Pages/RentStabilization/RentStabilization.tsx
@@ -28,8 +28,8 @@ export const RentStabilization: React.FC = () => {
       <div className="content-section">
         <div className="content-section__content"></div>
         <ContentBox
-          headerTitle="Why you need to know"
-          headerSubtitle="Good Cause Eviction Law does not cover rent stabilized apartments"
+          title="Why you need to know"
+          subtitle="Good Cause Eviction Law does not cover rent stabilized apartments"
         >
           <div className="content-box__section">
             <div className="content-box__section__content">
@@ -43,8 +43,8 @@ export const RentStabilization: React.FC = () => {
         </ContentBox>
 
         <ContentBox
-          headerTitle="WHAT YOU CAN DO"
-          headerSubtitle="How to find out if your apartment is rent stabilized"
+          title="WHAT YOU CAN DO"
+          subtitle="How to find out if your apartment is rent stabilized"
         >
           <div className="content-box__section">
             <div className="content-box__section__content">

--- a/src/Components/Pages/Results/Results.scss
+++ b/src/Components/Pages/Results/Results.scss
@@ -297,3 +297,31 @@ $eligibilityTablePaddingH: 36px;
     }
   }
 }
+
+.next-step {
+  --icon-size: 2.75rem; // 44px;
+  --icon-margin: 1.5rem; // 24px;
+
+  .eligibility__icon {
+    font-size: 1.875rem; //30px
+    margin-right: var(--icon-margin);
+
+    .eligible {
+      color: $GREEN;
+    }
+    .ineligible {
+      color: $RED;
+    }
+    .unknown {
+      color: $YELLOW;
+    }
+
+    svg {
+      width: var(--icon-size);
+      height: var(--icon-size);
+    }
+  }
+  .accordion__content {
+    margin-left: calc(var(--icon-size) + var(--icon-margin));
+  }
+}

--- a/src/Components/Pages/Results/Results.tsx
+++ b/src/Components/Pages/Results/Results.tsx
@@ -24,7 +24,7 @@ import {
 } from "../../../api/helpers";
 import { Address } from "../Home/Home";
 import { breadCrumbAddress, getDetermination } from "../../../helpers";
-import { ContentBox } from "../../ContentBox/ContentBox";
+import { ContentBox, ContentBoxItem } from "../../ContentBox/ContentBox";
 import { BreadCrumbs } from "../../BreadCrumbs/BreadCrumbs";
 import JFCLLinkInternal from "../../JFCLLinkInternal";
 import {
@@ -232,7 +232,7 @@ const EligibilityIcon: React.FC<{ determination?: Determination }> = ({
 }) => {
   switch (determination) {
     case "ELIGIBLE":
-      return <Icon icon="check" className={determination} title="Pass" />;
+      return <Icon icon="check" className="eligible" title="Pass" />;
     default:
       return (
         <Icon
@@ -342,62 +342,64 @@ const EligibilityNextSteps: React.FC<{
       }
     >
       {rentRegulationUnknown && (
-        <div className="content-box__section">
-          <span className="eligibility__icon">
-            <EligibilityIcon determination="UNKNOWN" />
-          </span>
-          <div className="content-box__section__content">
-            <div className="content-box__section__header">
-              We need to know if your apartment is rent stabilized.
-            </div>
-            <p>
-              The Good Cause Eviction law only covers tenants whose apartments
-              are not rent regulated. You told us that you are unsure of your
-              rent regulation status.
-            </p>
-            <JFCLLinkInternal to="/rent_stabilization">
-              Learn how to find out
-            </JFCLLinkInternal>
-          </div>
-        </div>
+        <ContentBoxItem
+          title="We need to know if your apartment is rent stabilized."
+          icon={
+            <span className="eligibility__icon">
+              <EligibilityIcon determination="UNKNOWN" />
+            </span>
+          }
+          className="next-step"
+          open
+        >
+          <p>
+            The Good Cause Eviction law only covers tenants whose apartments are
+            not rent regulated. You told us that you are unsure of your rent
+            regulation status.
+          </p>
+          <JFCLLinkInternal to="/rent_stabilization">
+            Learn how to find out
+          </JFCLLinkInternal>
+        </ContentBoxItem>
       )}
 
       {portfolioSizeUnknown && (
-        <div className="content-box__section">
-          <span className="eligibility__icon">
-            <EligibilityIcon determination="UNKNOWN" />
-          </span>
-          <div className="content-box__section__content">
-            <div className="content-box__section__header">
-              We need to know if your landlord owns more than 10 units.
-            </div>
-            {bldgData.related_properties.length ? (
-              <>
-                <p>
-                  {`Good Cause Eviction law only covers tenants whose landlord owns
+        <ContentBoxItem
+          title="We need to know if your landlord owns more than 10 units."
+          icon={
+            <span className="eligibility__icon">
+              <EligibilityIcon determination="UNKNOWN" />
+            </span>
+          }
+          className="next-step"
+          open
+        >
+          {bldgData.related_properties.length ? (
+            <>
+              <p>
+                {`Good Cause Eviction law only covers tenants whose landlord owns
                 more than 10 units. Your building has only ${bldgData.unitsres} apartments, but
                 your landlord may own other buildings.`}
-                </p>
+              </p>
 
-                <JFCLLinkInternal to="/portfolio_size">
-                  Learn how to find out
-                </JFCLLinkInternal>
-              </>
-            ) : (
-              <>
-                <p>
-                  {`Good Cause Eviction law only covers tenants whose landlord owns
+              <JFCLLinkInternal to="/portfolio_size">
+                Learn how to find out
+              </JFCLLinkInternal>
+            </>
+          ) : (
+            <>
+              <p>
+                {`Good Cause Eviction law only covers tenants whose landlord owns
                 more than 10 units. Your building has only ${bldgData.unitsres} apartments.`}
-                </p>
-                <br />
-                <p>
-                  We are unable to find other apartments your landlord might own
-                  in our records.
-                </p>
-              </>
-            )}
-          </div>
-        </div>
+              </p>
+              <br />
+              <p>
+                We are unable to find other apartments your landlord might own
+                in our records.
+              </p>
+            </>
+          )}
+        </ContentBoxItem>
       )}
 
       <div className="content-box__footer">

--- a/src/Components/Pages/Results/Results.tsx
+++ b/src/Components/Pages/Results/Results.tsx
@@ -24,10 +24,15 @@ import {
 } from "../../../api/helpers";
 import { Address } from "../Home/Home";
 import { breadCrumbAddress, getDetermination } from "../../../helpers";
-import { ContentBox, ContentBoxProps } from "../../ContentBox/ContentBox";
+import { ContentBox } from "../../ContentBox/ContentBox";
 import { BreadCrumbs } from "../../BreadCrumbs/BreadCrumbs";
-import JFCLLinkExternal from "../../JFCLLinkExternal";
 import JFCLLinkInternal from "../../JFCLLinkInternal";
+import {
+  GoodCauseExercisingRights,
+  GoodCauseProtections,
+  RentStabilizedProtections,
+  UniversalProtections,
+} from "../../KYRContent/KYRContent";
 import "./Results.scss";
 
 export const Results: React.FC = () => {
@@ -159,10 +164,7 @@ export const Results: React.FC = () => {
               </div>
 
               <div className="eligibility__table__container__print">
-                <ContentBox
-                  headerTitle="Your results"
-                  headerSubtitle="Coverage criteria"
-                >
+                <ContentBox title="Your results" subtitle="Coverage criteria">
                   <EligibilityCriteriaTable
                     eligibilityResults={eligibilityResults}
                   />
@@ -183,28 +185,22 @@ export const Results: React.FC = () => {
             />
           )}
 
-          {isRentStabilized && rentStabilizedProtections}
-
+          {isRentStabilized && <RentStabilizedProtections />}
           {determination === "UNKNOWN" && (
-            <GoodCauseProtections
-              headerTitle="KNOW YOUR RIGHTS"
-              headerSubtitle="Protections you might have under Good Cause Eviction law"
-            />
-          )}
-
-          {determination === "ELIGIBLE" && (
             <>
-              <GoodCauseProtections
-                headerTitle="KNOW YOUR RIGHTS"
-                headerSubtitle="Protections you have under Good Cause Eviction law"
-              />
-              {goodCauseExercisingRights}
+              <GoodCauseProtections subtitle="Protections you might have under Good Cause Eviction law" />
+              <UniversalProtections />
             </>
           )}
-
-          {determination === "INELIGIBLE" &&
-            !isRentStabilized &&
-            universalProtections}
+          {determination === "ELIGIBLE" && (
+            <>
+              <GoodCauseProtections />
+              <GoodCauseExercisingRights />
+            </>
+          )}
+          {determination === "INELIGIBLE" && !isRentStabilized && (
+            <UniversalProtections />
+          )}
 
           <div className="eligibility__footer">
             <h3 className="eligibility__footer__header">
@@ -338,8 +334,8 @@ const EligibilityNextSteps: React.FC<{
   ).length;
   return (
     <ContentBox
-      headerTitle="What this means for you"
-      headerSubtitle={
+      title="What this means for you"
+      subtitle={
         steps == 1
           ? "There is still one thing you need to verify"
           : `There are still ${steps} things you need to verify`
@@ -422,271 +418,6 @@ const EligibilityNextSteps: React.FC<{
     </ContentBox>
   );
 };
-
-const GoodCauseProtections = (props: Omit<ContentBoxProps, "children">) => (
-  <ContentBox {...props}>
-    <div className="content-box__section">
-      <div className="content-box__section__content">
-        <div className="content-box__section__header">
-          Your right to a lease renewal
-        </div>
-        <p>
-          Your landlord will need to provide a good cause reason for ending a
-          tenancy. This includes evicting tenants, not renewing a lease, or, if
-          the tenant does not have a lease, giving notice that the tenancy will
-          end.
-        </p>
-      </div>
-    </div>
-
-    <div className="content-box__section">
-      <div className="content-box__section__content">
-        <div className="content-box__section__header">
-          Your right to limited rent increases
-        </div>
-        <p>
-          Your landlord is not allowed to increase your rent at a rate higher
-          than the local standard. The local rent standard is set every year at
-          the rate of inflation plus 5%, with a maximum of 10% total.
-        </p>
-        <br />
-        <p>
-          As of May 1, 2024, the rate of inflation for the New York City area is
-          3.82%, meaning that the current local rent standard is 8.82%. A rent
-          increase of more than 8.82% could be found unreasonable by the court
-          if the rent was increased after April 20, 2024.
-        </p>
-      </div>
-    </div>
-
-    <div className="content-box__section">
-      <div className="content-box__section__content">
-        <p className="bold">
-          Learn more about Good Cause Eviction Law protections
-        </p>
-        <JFCLLinkExternal href="https://housingjusticeforall.org/kyr-good-cause">
-          Housing Justice for All Good Cause Eviction fact sheet
-        </JFCLLinkExternal>
-        <JFCLLinkExternal
-          href="https://www.metcouncilonhousing.org/help-answers/good-cause-eviction"
-          className="has-label"
-        >
-          Met Council on Housing Good Cause Eviction fact sheet
-        </JFCLLinkExternal>
-      </div>
-    </div>
-  </ContentBox>
-);
-
-const goodCauseExercisingRights = (
-  <ContentBox
-    headerTitle="EXERCISING YOUR RIGHTS"
-    headerSubtitle="Share your coverage with your landlord"
-  >
-    <div className="content-box__section">
-      <div className="content-box__section__content">
-        <p>
-          Assert your rights by printing your coverage results and sharing with
-          your landlord. You can use these results as an indicator that your
-          apartment is covered by Good Cause Eviction Law.
-        </p>
-      </div>
-    </div>
-
-    <div className="content-box__footer">
-      <div className="content-box__section__content">
-        <Button
-          labelText="Print my coverage results"
-          labelIcon="print"
-          variant="secondary"
-          className="disabled"
-        />
-      </div>
-    </div>
-  </ContentBox>
-);
-
-const rentStabilizedProtections = (
-  <ContentBox
-    headerTitle="EXERCISING YOUR RIGHTS"
-    headerSubtitle="Your right to limited rent increases"
-  >
-    <div className="content-box__section">
-      <div className="content-box__section__content">
-        <div className="content-box__section__header">
-          Your right to limited rent increases
-        </div>
-        <p>
-          For rent-stabilized leases being renewed between October 1, 2024 and
-          September 30, 2025 the legal rent may be increased at the following
-          levels: for a one-year renewal there is a 2.75% increase, or for a
-          two-year renewal there is a 5.25% increase.
-        </p>
-        <JFCLLinkExternal href="https://hcr.ny.gov/system/files/documents/2024/10/fact-sheet-26-10-2024.pdf">
-          Learn about rent increase rights
-        </JFCLLinkExternal>
-      </div>
-    </div>
-
-    <div className="content-box__section">
-      <div className="content-box__section__content">
-        <div className="content-box__section__header">
-          Your right to a lease renewal
-        </div>
-        <p>
-          If you are rent-stabilized your landlord cannot simply decide they
-          don’t want you as a tenant anymore, they are limited to certain
-          reasons for evicting you.
-        </p>
-        <JFCLLinkExternal href="https://rentguidelinesboard.cityofnewyork.us/resources/faqs/leases-renewal-vacancy/#landlord:~:text=If%20your%20apartment%20is%20rent,before%20the%20existing%20lease%20expires">
-          Learn about lease renewal rights
-        </JFCLLinkExternal>
-      </div>
-    </div>
-
-    <div className="content-box__section">
-      <div className="content-box__section__content">
-        <div className="content-box__section__header">
-          Your right to succession
-        </div>
-        <p>
-          If you are the immediate family member of a rent-stabilized tenant and
-          have been living with them immediately prior to their moving or
-          passing away, you might be entitled to take over the lease.
-        </p>
-        <JFCLLinkExternal href="https://www.metcouncilonhousing.org/help-answers/succession-rights-in-rent-stabilized-and-rent-controlled-apartments/">
-          Learn about succession rights
-        </JFCLLinkExternal>
-      </div>
-    </div>
-  </ContentBox>
-);
-
-const universalProtections = (
-  <ContentBox
-    headerTitle="KNOW YOUR RIGHTS"
-    headerSubtitle="Protections you still have as a tenant in NYC"
-  >
-    <div className="content-box__section">
-      <div className="content-box__section__content">
-        <div className="content-box__section__header">
-          Your eviction protections
-        </div>
-        <p>
-          The only way your landlord can evict you is through housing court.
-          Lockouts (also known as unlawful evictions or self-help evictions) are
-          illegal. All tenants, including those in private residential programs,
-          have the right to stay in their home unless they choose to leave or
-          are evicted through a court process.
-        </p>
-        <br />
-        <p className="bold">Learn more about the eviction process</p>
-        <JFCLLinkExternal
-          href="https://hcr.ny.gov/eviction"
-          className="has-label"
-        >
-          NY Homes and Community Renewal
-        </JFCLLinkExternal>
-        <br />
-        <br />
-        <p className="bold">See if you are eligible for a free attorney</p>
-        <JFCLLinkExternal
-          href="https://www.evictionfreenyc.org"
-          className="has-label"
-        >
-          Eviction Free NYC
-        </JFCLLinkExternal>
-      </div>
-    </div>
-
-    <div className="content-box__section">
-      <div className="content-box__section__content">
-        <div className="content-box__section__header">
-          Your right to a liveable home
-        </div>
-        <p>
-          Tenants have the right to live in a safe, sanitary, and
-          well-maintained apartment, including public areas of the building.
-          This right is implied in every residential lease, and any lease
-          provision that waives it is void. If your landlord is not providing
-          these conditions in your apartment or building, there are actions you
-          can take to exercise your rights.
-        </p>
-        <br />
-        <p className="bold">Learn about warranty of habitability</p>
-        <JFCLLinkExternal
-          href="https://nycourts.gov/courts/nyc/housing/pdfs/warrantyofhabitability.pdf"
-          className="has-label"
-        >
-          NY Courts
-        </JFCLLinkExternal>
-        <br />
-        <br />
-        <p className="bold">Learn how tenant associations can help</p>
-        <JFCLLinkExternal
-          href="https://www.metcouncilonhousing.org/help-answers/forming-a-tenants-association"
-          className="has-label"
-        >
-          Met Council on Housing
-        </JFCLLinkExternal>
-        <br />
-        <br />
-        <p className="bold">Notify your landlord of repair issues</p>
-        <JFCLLinkExternal
-          href="https://app.justfix.org/loc/splash"
-          className="has-label"
-        >
-          JustFix’s Letter of Complaint
-        </JFCLLinkExternal>
-      </div>
-    </div>
-
-    <div className="content-box__section">
-      <div className="content-box__section__content">
-        <div className="content-box__section__header">
-          Your rights if you’re being discriminated against
-        </div>
-        <p>
-          Your landlord can’t evict you based on your race, religion, gender,
-          national origin, familial status, or disability. New York State law
-          promises protection from discrimination, banning bias based on age,
-          sexual orientation, and military status.
-        </p>
-        <p>
-          Source of income discrimination the illegal practice by landlords,
-          owners, and real estate brokers of refusing to rent to current or
-          prospective tenants seeking to pay for housing with housing assistance
-          vouchers, subsidies, or other forms of public assistance.
-        </p>
-        <br />
-        <p className="bold">Learn more about fair housing</p>
-        <JFCLLinkExternal
-          href="https://www.nyc.gov/site/fairhousing/about/what-is-fair-housing.page"
-          className="has-label"
-        >
-          Fair Housing NYC
-        </JFCLLinkExternal>
-        <br />
-        <br />
-        <p className="bold">
-          Learn more about lawful source of income discrimination
-        </p>
-        <JFCLLinkExternal
-          href="https://www.nyc.gov/site/fairhousing/renters/lawful-source-of-income.page"
-          className="has-label"
-        >
-          Lawful source of income
-        </JFCLLinkExternal>
-        <br />
-        <br />
-        <p className="bold">Report source of income discrimination</p>
-        <JFCLLinkExternal href="https://weunlock.nyc" className="has-label">
-          Unlock NYC
-        </JFCLLinkExternal>
-      </div>
-    </div>
-  </ContentBox>
-);
 
 const EligibilityResultHeadline: React.FC<{
   address: string;


### PR DESCRIPTION
Adds a simple accordion component and uses that for all content box sections and the related-buildings.
I moved around styles for better separation between pages and components. 
Moved all the know-your-rights content boxes to a separate file to simplify the results file and since we'll reuse in standalone page. Also changed them all to components to easily change the header text based on context.

[sc-15965]