### PR TITLE
refactor results styles, update print styles, expand accordions

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1,5 +1,19 @@
 @import "colors.scss";
 @import "variables.scss";
+@import "mixins.scss";
+
+@media print {
+  html {
+    font-size: 12px;
+  }
+}
+
+// removes default print page header/footer (date, url, etc.)
+@page {
+  size: auto;
+  // TODO: should remove margin for PDF if possible
+  margin: 24px;
+}
 
 #container {
   display: flex;
@@ -21,10 +35,6 @@
   text-wrap: nowrap;
   z-index: 100;
 
-  @media print {
-    display: none;
-  }
-
   h1 {
     color: $OFF_WHITE_100;
     font-size: 1.25rem; // 20px
@@ -36,12 +46,24 @@
     color: $WHITE;
     text-decoration: none;
   }
+
+  @media print {
+    position: unset;
+    background-color: unset;
+    h1,
+    .header__link {
+      color: black;
+      @include body_large_desktop;
+    }
+  }
 }
 
 #main {
   flex-grow: 1;
   margin-top: $headerH;
-  // padding-top: 2.25rem; // 36px
+  @media print {
+    margin-top: 0;
+  }
 
   #content {
     height: 100%;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ const Layout = () => {
       <header id="header">
         <h1>
           <Link to="/" className="header__link">
-            Good Cause Eviction
+            Good Cause Eviction NYC
           </Link>
         </h1>
       </header>

--- a/src/Components/Footer/Footer.scss
+++ b/src/Components/Footer/Footer.scss
@@ -49,3 +49,9 @@
     }
   }
 }
+
+@media print {
+  .footer {
+    display: none;
+  }
+}

--- a/src/Components/Header/Header.tsx
+++ b/src/Components/Header/Header.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { BreadCrumbs } from "../BreadCrumbs/BreadCrumbs";
 import { Address } from "../Pages/Home/Home";
 import { BackLink } from "../JFCLLinkInternal";
+import { toTitleCase } from "../../helpers";
 
 type HeaderProps = {
   title: string | React.ReactNode;
@@ -26,6 +27,11 @@ export const Header: React.FC<HeaderProps> = ({
     <div className="headline-section">
       <div className="headline-section__content">
         {showBreadcrumbs && <BreadCrumbs address={address} />}
+        <div className="headline-section__address__print">
+          {toTitleCase(
+            `${address?.houseNumber} ${address?.streetName}, ${address?.zipcode}`
+          )}
+        </div>
         {isGuide && (
           <div className="headline-section__back-link">
             <BackLink to="/results">Back to Coverage Result</BackLink>

--- a/src/Components/KYRContent/KYRContent.tsx
+++ b/src/Components/KYRContent/KYRContent.tsx
@@ -15,111 +15,114 @@ export const UniversalProtections: React.FC<KYRContentBoxProps> = ({
   subtitle: headerSubtitle = "Protections that all New Yorkers have",
   children,
 }) => (
-  <ContentBox title={title} subtitle={headerSubtitle}>
-    <ContentBoxItem title="Your eviction protections">
-      <p>
-        The only way your landlord can evict you is through housing court.
-        Lockouts (also known as unlawful evictions or self-help evictions) are
-        illegal. All tenants, including those in private residential programs,
-        have the right to stay in their home unless they choose to leave or are
-        evicted through a court process.
-      </p>
-      <br />
-      <p className="bold">Learn more about the eviction process</p>
-      <JFCLLinkExternal
-        href="https://hcr.ny.gov/eviction"
-        className="has-label"
-      >
-        NY Homes and Community Renewal
-      </JFCLLinkExternal>
-      <br />
-      <br />
-      <p className="bold">See if you are eligible for a free attorney</p>
-      <JFCLLinkExternal
-        href="https://www.evictionfreenyc.org"
-        className="has-label"
-      >
-        Eviction Free NYC
-      </JFCLLinkExternal>
-    </ContentBoxItem>
+  <>
+    <ContentBox title={title} subtitle={headerSubtitle}>
+      <ContentBoxItem title="Your eviction protections">
+        <p>
+          The only way your landlord can evict you is through housing court.
+          Lockouts (also known as unlawful evictions or self-help evictions) are
+          illegal. All tenants, including those in private residential programs,
+          have the right to stay in their home unless they choose to leave or
+          are evicted through a court process.
+        </p>
+        <br />
+        <p className="bold">Learn more about the eviction process</p>
+        <JFCLLinkExternal
+          href="https://hcr.ny.gov/eviction"
+          className="has-label"
+        >
+          NY Homes and Community Renewal
+        </JFCLLinkExternal>
+        <br />
+        <br />
+        <p className="bold">See if you are eligible for a free attorney</p>
+        <JFCLLinkExternal
+          href="https://www.evictionfreenyc.org"
+          className="has-label"
+        >
+          Eviction Free NYC
+        </JFCLLinkExternal>
+      </ContentBoxItem>
 
-    <ContentBoxItem title="Your right to a liveable home">
-      <p>
-        Tenants have the right to live in a safe, sanitary, and well-maintained
-        apartment, including public areas of the building. This right is implied
-        in every residential lease, and any lease provision that waives it is
-        void. If your landlord is not providing these conditions in your
-        apartment or building, there are actions you can take to exercise your
-        rights.
-      </p>
-      <br />
-      <p className="bold">Learn about warranty of habitability</p>
-      <JFCLLinkExternal
-        href="https://nycourts.gov/courts/nyc/housing/pdfs/warrantyofhabitability.pdf"
-        className="has-label"
-      >
-        NY Courts
-      </JFCLLinkExternal>
-      <br />
-      <br />
-      <p className="bold">Learn how tenant associations can help</p>
-      <JFCLLinkExternal
-        href="https://www.metcouncilonhousing.org/help-answers/forming-a-tenants-association"
-        className="has-label"
-      >
-        Met Council on Housing
-      </JFCLLinkExternal>
-      <br />
-      <br />
-      <p className="bold">Notify your landlord of repair issues</p>
-      <JFCLLinkExternal
-        href="https://app.justfix.org/loc/splash"
-        className="has-label"
-      >
-        JustFix’s Letter of Complaint
-      </JFCLLinkExternal>
-    </ContentBoxItem>
-    <ContentBoxItem title="Your rights if you’re being discriminated against">
-      <p>
-        Your landlord can’t evict you based on your race, religion, gender,
-        national origin, familial status, or disability. New York State law
-        promises protection from discrimination, banning bias based on age,
-        sexual orientation, and military status.
-      </p>
-      <p>
-        Source of income discrimination the illegal practice by landlords,
-        owners, and real estate brokers of refusing to rent to current or
-        prospective tenants seeking to pay for housing with housing assistance
-        vouchers, subsidies, or other forms of public assistance.
-      </p>
-      <br />
-      <p className="bold">Learn more about fair housing</p>
-      <JFCLLinkExternal
-        href="https://www.nyc.gov/site/fairhousing/about/what-is-fair-housing.page"
-        className="has-label"
-      >
-        Fair Housing NYC
-      </JFCLLinkExternal>
-      <br />
-      <br />
-      <p className="bold">
-        Learn more about lawful source of income discrimination
-      </p>
-      <JFCLLinkExternal
-        href="https://www.nyc.gov/site/fairhousing/renters/lawful-source-of-income.page"
-        className="has-label"
-      >
-        Lawful source of income
-      </JFCLLinkExternal>
-      <br />
-      <br />
-      <p className="bold">Report source of income discrimination</p>
-      <JFCLLinkExternal href="https://weunlock.nyc" className="has-label">
-        Unlock NYC
-      </JFCLLinkExternal>
-    </ContentBoxItem>
-    {children}
-  </ContentBox>
+      <ContentBoxItem title="Your right to a liveable home">
+        <p>
+          Tenants have the right to live in a safe, sanitary, and
+          well-maintained apartment, including public areas of the building.
+          This right is implied in every residential lease, and any lease
+          provision that waives it is void. If your landlord is not providing
+          these conditions in your apartment or building, there are actions you
+          can take to exercise your rights.
+        </p>
+        <br />
+        <p className="bold">Learn about warranty of habitability</p>
+        <JFCLLinkExternal
+          href="https://nycourts.gov/courts/nyc/housing/pdfs/warrantyofhabitability.pdf"
+          className="has-label"
+        >
+          NY Courts
+        </JFCLLinkExternal>
+        <br />
+        <br />
+        <p className="bold">Learn how tenant associations can help</p>
+        <JFCLLinkExternal
+          href="https://www.metcouncilonhousing.org/help-answers/forming-a-tenants-association"
+          className="has-label"
+        >
+          Met Council on Housing
+        </JFCLLinkExternal>
+        <br />
+        <br />
+        <p className="bold">Notify your landlord of repair issues</p>
+        <JFCLLinkExternal
+          href="https://app.justfix.org/loc/splash"
+          className="has-label"
+        >
+          JustFix’s Letter of Complaint
+        </JFCLLinkExternal>
+      </ContentBoxItem>
+      <ContentBoxItem title="Your rights if you’re being discriminated against">
+        <p>
+          Your landlord can’t evict you based on your race, religion, gender,
+          national origin, familial status, or disability. New York State law
+          promises protection from discrimination, banning bias based on age,
+          sexual orientation, and military status.
+        </p>
+        <p>
+          Source of income discrimination the illegal practice by landlords,
+          owners, and real estate brokers of refusing to rent to current or
+          prospective tenants seeking to pay for housing with housing assistance
+          vouchers, subsidies, or other forms of public assistance.
+        </p>
+        <br />
+        <p className="bold">Learn more about fair housing</p>
+        <JFCLLinkExternal
+          href="https://www.nyc.gov/site/fairhousing/about/what-is-fair-housing.page"
+          className="has-label"
+        >
+          Fair Housing NYC
+        </JFCLLinkExternal>
+        <br />
+        <br />
+        <p className="bold">
+          Learn more about lawful source of income discrimination
+        </p>
+        <JFCLLinkExternal
+          href="https://www.nyc.gov/site/fairhousing/renters/lawful-source-of-income.page"
+          className="has-label"
+        >
+          Lawful source of income
+        </JFCLLinkExternal>
+        <br />
+        <br />
+        <p className="bold">Report source of income discrimination</p>
+        <JFCLLinkExternal href="https://weunlock.nyc" className="has-label">
+          Unlock NYC
+        </JFCLLinkExternal>
+      </ContentBoxItem>
+      {children}
+    </ContentBox>
+    <div className="divider__print" />
+  </>
 );
 
 export const GoodCauseProtections: React.FC<KYRContentBoxProps> = ({
@@ -127,44 +130,47 @@ export const GoodCauseProtections: React.FC<KYRContentBoxProps> = ({
   subtitle = "Protections you have under Good Cause Eviction",
   children,
 }) => (
-  <ContentBox title={title} subtitle={subtitle}>
-    <ContentBoxItem title="Your right to a lease renewal">
-      <p>
-        Your landlord will need to provide a good cause reason for ending a
-        tenancy. This includes evicting tenants, not renewing a lease, or, if
-        the tenant does not have a lease, giving notice that the tenancy will
-        end.
-      </p>
-    </ContentBoxItem>
+  <>
+    <ContentBox title={title} subtitle={subtitle}>
+      <ContentBoxItem title="Your right to a lease renewal">
+        <p>
+          Your landlord will need to provide a good cause reason for ending a
+          tenancy. This includes evicting tenants, not renewing a lease, or, if
+          the tenant does not have a lease, giving notice that the tenancy will
+          end.
+        </p>
+      </ContentBoxItem>
 
-    <ContentBoxItem title="Your right to limited rent increases">
-      <p>
-        Your landlord is not allowed to increase your rent at a rate higher than
-        the local standard. The local rent standard is set every year at the
-        rate of inflation plus 5%, with a maximum of 10% total.
-      </p>
-      <br />
-      <p>
-        As of May 1, 2024, the rate of inflation for the New York City area is
-        3.82%, meaning that the current local rent standard is 8.82%. A rent
-        increase of more than 8.82% could be found unreasonable by the court if
-        the rent was increased after April 20, 2024.
-      </p>
-    </ContentBoxItem>
+      <ContentBoxItem title="Your right to limited rent increases">
+        <p>
+          Your landlord is not allowed to increase your rent at a rate higher
+          than the local standard. The local rent standard is set every year at
+          the rate of inflation plus 5%, with a maximum of 10% total.
+        </p>
+        <br />
+        <p>
+          As of May 1, 2024, the rate of inflation for the New York City area is
+          3.82%, meaning that the current local rent standard is 8.82%. A rent
+          increase of more than 8.82% could be found unreasonable by the court
+          if the rent was increased after April 20, 2024.
+        </p>
+      </ContentBoxItem>
 
-    <ContentBoxItem title="Learn more about Good Cause Eviction Law protections">
-      <JFCLLinkExternal href="https://housingjusticeforall.org/kyr-good-cause">
-        Housing Justice for All Good Cause Eviction fact sheet
-      </JFCLLinkExternal>
-      <JFCLLinkExternal
-        href="https://www.metcouncilonhousing.org/help-answers/good-cause-eviction"
-        className="has-label"
-      >
-        Met Council on Housing Good Cause Eviction fact sheet
-      </JFCLLinkExternal>
-    </ContentBoxItem>
-    {children}
-  </ContentBox>
+      <ContentBoxItem title="Learn more about Good Cause Eviction Law protections">
+        <JFCLLinkExternal href="https://housingjusticeforall.org/kyr-good-cause">
+          Housing Justice for All Good Cause Eviction fact sheet
+        </JFCLLinkExternal>
+        <JFCLLinkExternal
+          href="https://www.metcouncilonhousing.org/help-answers/good-cause-eviction"
+          className="has-label"
+        >
+          Met Council on Housing Good Cause Eviction fact sheet
+        </JFCLLinkExternal>
+      </ContentBoxItem>
+      {children}
+    </ContentBox>
+    <div className="divider__print" />
+  </>
 );
 
 export const GoodCauseExercisingRights: React.FC<KYRContentBoxProps> = ({
@@ -172,40 +178,44 @@ export const GoodCauseExercisingRights: React.FC<KYRContentBoxProps> = ({
   subtitle = "How to assert your rights",
   children,
 }) => (
-  <ContentBox title={title} subtitle={subtitle}>
-    <ContentBoxItem title="Share your coverage with your landlord">
-      <p>
-        Assert your rights by printing your coverage results and sharing with
-        your landlord. You can use these results as an indicator that your
-        apartment is covered by Good Cause Eviction Law.
-      </p>
-      {/* TODO: add email/download/print coverage result buttons */}
-    </ContentBoxItem>
-    <ContentBoxItem title="Organize with your neighbors">
-      <p>
-        Since your apartment is covered by Good Cause Eviction, there is a good
-        chance other apartments in your building are covered as well. Organizing
-        with your neighbors can help you assert your rights as a group.
-      </p>
-      <JFCLLinkExternal href="">
-        Tenant Organizing Toolkit from Housing Justice for All
-      </JFCLLinkExternal>
-    </ContentBoxItem>
-    <ContentBoxItem title="Reach out to Met Council on Housing">
-      <p>
-        The Met Council on Housing helps organize tenants to stand up not only
-        for their individual rights, but also for changes to housing policies.
-        You can visit the website, or use their hotline to get answers to your
-        rights as a tenant, and understand your options for dealing with a
-        housing situation.
-      </p>
-      <JFCLLinkExternal href="">Met Council on Housing</JFCLLinkExternal>
-      <JFCLLinkExternal href="">
-        Call Met Council on Housing Hotline
-      </JFCLLinkExternal>
-    </ContentBoxItem>
-    {children}
-  </ContentBox>
+  <>
+    <ContentBox title={title} subtitle={subtitle}>
+      <ContentBoxItem title="Share your coverage with your landlord">
+        <p>
+          Assert your rights by printing your coverage results and sharing with
+          your landlord. You can use these results as an indicator that your
+          apartment is covered by Good Cause Eviction Law.
+        </p>
+        {/* TODO: add email/download/print coverage result buttons */}
+      </ContentBoxItem>
+      <ContentBoxItem title="Organize with your neighbors">
+        <p>
+          Since your apartment is covered by Good Cause Eviction, there is a
+          good chance other apartments in your building are covered as well.
+          Organizing with your neighbors can help you assert your rights as a
+          group.
+        </p>
+        <JFCLLinkExternal href="">
+          Tenant Organizing Toolkit from Housing Justice for All
+        </JFCLLinkExternal>
+      </ContentBoxItem>
+      <ContentBoxItem title="Reach out to Met Council on Housing">
+        <p>
+          The Met Council on Housing helps organize tenants to stand up not only
+          for their individual rights, but also for changes to housing policies.
+          You can visit the website, or use their hotline to get answers to your
+          rights as a tenant, and understand your options for dealing with a
+          housing situation.
+        </p>
+        <JFCLLinkExternal href="">Met Council on Housing</JFCLLinkExternal>
+        <JFCLLinkExternal href="">
+          Call Met Council on Housing Hotline
+        </JFCLLinkExternal>
+      </ContentBoxItem>
+      {children}
+    </ContentBox>
+    <div className="divider__print" />
+  </>
 );
 
 export const RentStabilizedProtections: React.FC<KYRContentBoxProps> = ({
@@ -213,42 +223,45 @@ export const RentStabilizedProtections: React.FC<KYRContentBoxProps> = ({
   subtitle = "Protections you have as a rent stabilized tenant",
   children,
 }) => (
-  <ContentBox title={title} subtitle={subtitle}>
-    <ContentBoxItem title="Your right to limited rent increases">
-      <p>
-        For rent-stabilized leases being renewed between October 1, 2024 and
-        September 30, 2025 the legal rent may be increased at the following
-        levels: for a one-year renewal there is a 2.75% increase, or for a
-        two-year renewal there is a 5.25% increase.
-      </p>
-      <JFCLLinkExternal href="https://hcr.ny.gov/system/files/documents/2024/10/fact-sheet-26-10-2024.pdf">
-        Learn about rent increase rights
-      </JFCLLinkExternal>
-    </ContentBoxItem>
+  <>
+    <ContentBox title={title} subtitle={subtitle}>
+      <ContentBoxItem title="Your right to limited rent increases">
+        <p>
+          For rent-stabilized leases being renewed between October 1, 2024 and
+          September 30, 2025 the legal rent may be increased at the following
+          levels: for a one-year renewal there is a 2.75% increase, or for a
+          two-year renewal there is a 5.25% increase.
+        </p>
+        <JFCLLinkExternal href="https://hcr.ny.gov/system/files/documents/2024/10/fact-sheet-26-10-2024.pdf">
+          Learn about rent increase rights
+        </JFCLLinkExternal>
+      </ContentBoxItem>
 
-    <ContentBoxItem title="Your right to a lease renewal">
-      <p>
-        If you are rent-stabilized your landlord cannot simply decide they don’t
-        want you as a tenant anymore, they are limited to certain reasons for
-        evicting you.
-      </p>
-      <JFCLLinkExternal href="https://rentguidelinesboard.cityofnewyork.us/resources/faqs/leases-renewal-vacancy/#landlord:~:text=If%20your%20apartment%20is%20rent,before%20the%20existing%20lease%20expires">
-        Learn about lease renewal rights
-      </JFCLLinkExternal>
-    </ContentBoxItem>
+      <ContentBoxItem title="Your right to a lease renewal">
+        <p>
+          If you are rent-stabilized your landlord cannot simply decide they
+          don’t want you as a tenant anymore, they are limited to certain
+          reasons for evicting you.
+        </p>
+        <JFCLLinkExternal href="https://rentguidelinesboard.cityofnewyork.us/resources/faqs/leases-renewal-vacancy/#landlord:~:text=If%20your%20apartment%20is%20rent,before%20the%20existing%20lease%20expires">
+          Learn about lease renewal rights
+        </JFCLLinkExternal>
+      </ContentBoxItem>
 
-    <ContentBoxItem title="Your right to succession">
-      <p>
-        If you are the immediate family member of a rent-stabilized tenant and
-        have been living with them immediately prior to their moving or passing
-        away, you might be entitled to take over the lease.
-      </p>
-      <JFCLLinkExternal href="https://www.metcouncilonhousing.org/help-answers/succession-rights-in-rent-stabilized-and-rent-controlled-apartments/">
-        Learn about succession rights
-      </JFCLLinkExternal>
-    </ContentBoxItem>
-    {children}
-  </ContentBox>
+      <ContentBoxItem title="Your right to succession">
+        <p>
+          If you are the immediate family member of a rent-stabilized tenant and
+          have been living with them immediately prior to their moving or
+          passing away, you might be entitled to take over the lease.
+        </p>
+        <JFCLLinkExternal href="https://www.metcouncilonhousing.org/help-answers/succession-rights-in-rent-stabilized-and-rent-controlled-apartments/">
+          Learn about succession rights
+        </JFCLLinkExternal>
+      </ContentBoxItem>
+      {children}
+    </ContentBox>
+    <div className="divider__print" />
+  </>
 );
 
 export const NYCHAProtections: React.FC<KYRContentBoxProps> = ({
@@ -256,40 +269,43 @@ export const NYCHAProtections: React.FC<KYRContentBoxProps> = ({
   subtitle = "Protections you have if you live in NYCHA housing",
   children,
 }) => (
-  <ContentBox title={title} subtitle={subtitle}>
-    <ContentBoxItem title="Your right to limited rent increases">
-      <p>
-        For rent-stabilized leases being renewed between October 1, 2024 and
-        September 30, 2025 the legal rent may be increased at the following
-        levels: for a one-year renewal there is a 2.75% increase, or for a
-        two-year renewal there is a 5.25% increase.
-      </p>
-      <JFCLLinkExternal href="https://hcr.ny.gov/system/files/documents/2024/10/fact-sheet-26-10-2024.pdf">
-        Learn about rent increase rights
-      </JFCLLinkExternal>
-    </ContentBoxItem>
+  <>
+    <ContentBox title={title} subtitle={subtitle}>
+      <ContentBoxItem title="Your right to limited rent increases">
+        <p>
+          For rent-stabilized leases being renewed between October 1, 2024 and
+          September 30, 2025 the legal rent may be increased at the following
+          levels: for a one-year renewal there is a 2.75% increase, or for a
+          two-year renewal there is a 5.25% increase.
+        </p>
+        <JFCLLinkExternal href="https://hcr.ny.gov/system/files/documents/2024/10/fact-sheet-26-10-2024.pdf">
+          Learn about rent increase rights
+        </JFCLLinkExternal>
+      </ContentBoxItem>
 
-    <ContentBoxItem title="Your right to a lease renewal">
-      <p>
-        If you are rent-stabilized your landlord cannot simply decide they don’t
-        want you as a tenant anymore, they are limited to certain reasons for
-        evicting you.
-      </p>
-      <JFCLLinkExternal href="https://rentguidelinesboard.cityofnewyork.us/resources/faqs/leases-renewal-vacancy/#landlord:~:text=If%20your%20apartment%20is%20rent,before%20the%20existing%20lease%20expires">
-        Learn about lease renewal rights
-      </JFCLLinkExternal>
-    </ContentBoxItem>
+      <ContentBoxItem title="Your right to a lease renewal">
+        <p>
+          If you are rent-stabilized your landlord cannot simply decide they
+          don’t want you as a tenant anymore, they are limited to certain
+          reasons for evicting you.
+        </p>
+        <JFCLLinkExternal href="https://rentguidelinesboard.cityofnewyork.us/resources/faqs/leases-renewal-vacancy/#landlord:~:text=If%20your%20apartment%20is%20rent,before%20the%20existing%20lease%20expires">
+          Learn about lease renewal rights
+        </JFCLLinkExternal>
+      </ContentBoxItem>
 
-    <ContentBoxItem title="Your right to succession">
-      <p>
-        If you are the immediate family member of a rent-stabilized tenant and
-        have been living with them immediately prior to their moving or passing
-        away, you might be entitled to take over the lease.
-      </p>
-      <JFCLLinkExternal href="https://www.metcouncilonhousing.org/help-answers/succession-rights-in-rent-stabilized-and-rent-controlled-apartments/">
-        Learn about succession rights
-      </JFCLLinkExternal>
-    </ContentBoxItem>
-    {children}
-  </ContentBox>
+      <ContentBoxItem title="Your right to succession">
+        <p>
+          If you are the immediate family member of a rent-stabilized tenant and
+          have been living with them immediately prior to their moving or
+          passing away, you might be entitled to take over the lease.
+        </p>
+        <JFCLLinkExternal href="https://www.metcouncilonhousing.org/help-answers/succession-rights-in-rent-stabilized-and-rent-controlled-apartments/">
+          Learn about succession rights
+        </JFCLLinkExternal>
+      </ContentBoxItem>
+      {children}
+    </ContentBox>
+    <div className="divider__print" />
+  </>
 );

--- a/src/Components/Pages/Results/Results.scss
+++ b/src/Components/Pages/Results/Results.scss
@@ -5,328 +5,236 @@
 
 $eligibilityTablePaddingH: 36px;
 
-.eligibility__loading {
-  margin: 3rem 0;
-}
-
-.eligibility__error {
-  margin: 3rem 0;
-}
-
-.covered-pill {
-  display: inline-flex;
-  padding: 0px 18px 4px;
-  color: $WHITE;
-  border-radius: 44px;
-  background-color: $GREEN;
-  white-space: nowrap;
-  height: calc(1em + 4px);
-
-  &.covered-pill--ineligible {
-    background-color: $ORANGE;
-    color: $OFF_BLACK;
+#results-page {
+  .eligibility__loading,
+  .eligibility__error {
+    margin: 3rem 0;
   }
 
-  &.covered-pill--unknown {
-    background-color: $YELLOW;
-    color: $OFF_BLACK;
-  }
-}
+  .covered-pill {
+    display: inline-flex;
+    padding: 0px 18px 4px;
+    color: $WHITE;
+    border-radius: 44px;
+    background-color: $GREEN;
+    white-space: nowrap;
+    height: calc(1em + 4px);
 
-.covered-underline {
-  text-decoration: underline;
-  color: $OFF_BLACK;
-}
+    &.covered-pill--ineligible {
+      background-color: $ORANGE;
+      color: $OFF_BLACK;
+    }
 
-.eligibility__toggle {
-  align-self: flex-start;
-  &.open {
-    margin-bottom: 2.25rem; // 36px
+    &.covered-pill--unknown {
+      background-color: $YELLOW;
+      color: $OFF_BLACK;
+    }
   }
-  &.closed {
-    margin-bottom: 0.8125rem; // 13px
+
+  .eligibility__table,
+  .protections-on-next-page__print {
+    border-radius: 4px;
+    border: 2px solid $GREY_NEW;
+    padding: 1.5rem $eligibilityTablePaddingH; // 24px
+    margin-top: 3rem; // 48px
+    max-width: $contentBoxWidth - (2 * $eligibilityTablePaddingH);
+    background-color: $WHITE;
+  }
+
+  .eligibility__table__header {
+    display: flex;
+    flex-direction: column;
+    padding: 1.125rem 1.125rem 2.25rem 1.125rem; // 20px 20px 36px 20px;
+    gap: 0.75rem; // 12px
+    border-bottom: 1px solid $GREY_NEW;
+
+    span {
+      @include body_large_desktop;
+    }
+    p {
+      @include body_standard_desktop;
+      margin: 0;
+    }
+  }
+
+  .eligibility__table__list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .eligibility__table__footer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: $eligibilityTablePaddingH 0 0;
+    @include body_large_desktop;
+
+    .eligibility__table__footer__link {
+      @include body_standard_desktop;
+      margin-top: 0.625rem; //10px
+    }
+
+    a {
+      color: black;
+      margin-left: 0.625rem; //10px
+    }
+  }
+
+  .eligibility__row {
+    display: flex;
+    border-bottom: 1px solid $GREY_NEW;
+    align-items: center;
+    padding: 20px 0;
+
+    .eligibility__row__icon {
+      padding: 0 1.25rem; // 0 20px
+      font-size: 1.875rem; //30px
+      width: 1.875rem; //30px
+    }
+
+    .eligibility__row__info {
+      display: flex;
+      flex-direction: column;
+      flex-shrink: 0;
+      width: 320px;
+      padding-right: 1rem;
+      box-sizing: border-box;
+      gap: 10px;
+    }
+
+    .eligibility__row__criteria {
+      @include eyebrow_small_desktop;
+    }
+
+    .eligibility__row__requirement {
+      @include body_standard_desktop;
+    }
+
+    .eligibility__row__userValue {
+      @include body_standard_desktop;
+      margin: 0 1.25rem; // 20px
+      box-sizing: border-box;
+      flex-grow: 1;
+
+      p {
+        margin: 0 0 0.625rem 0;
+      }
+    }
+  }
+
+  .eligible {
+    color: $GREEN;
+  }
+  .ineligible {
+    color: $YELLOW;
+  }
+  .unknown {
+    color: $YELLOW;
+  }
+
+  .eligibility__footer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin: 2.625rem 0; //42px
+
+    .eligibility__footer__header {
+      @include h3_desktop;
+      margin: 0 0 $eligibilityTablePaddingH 0;
+      text-align: center;
+    }
+  }
+
+  .next-step {
+    --icon-size: 2.75rem; // 44px;
+    --icon-margin: 1.5rem; // 24px;
+
+    .eligibility__icon {
+      font-size: 1.875rem; //30px
+      margin-right: var(--icon-margin);
+
+      svg {
+        width: var(--icon-size);
+        height: var(--icon-size);
+      }
+    }
+    .accordion__content {
+      margin-left: calc(var(--icon-size) + var(--icon-margin));
+    }
   }
 }
 
 @media screen {
-  .eligibility__result__print {
-    display: none;
-  }
-
-  .eligibility__table__container__print {
-    display: none;
-  }
-
-  .eligibility__table {
-    border-radius: 4px;
-    border: 2px solid $GREY_NEW;
-    padding: 1.5rem $eligibilityTablePaddingH; // 24px __
-    max-width: $contentBoxWidth - (2 * $eligibilityTablePaddingH);
-    background-color: $WHITE;
-  }
-}
-
-.eligibility__table {
-  margin-top: 3rem; // 48px
-}
-
-.eligibility__table__header {
-  display: flex;
-  flex-direction: column;
-  padding: 1.125rem 1.125rem 2.25rem 1.125rem; // 20px 20px 36px 20px;
-  gap: 0.75rem; // 12px
-  border-bottom: 1px solid $GREY_NEW;
-
-  span {
-    @include body_large_desktop;
-  }
-  p {
-    @include body_standard_desktop;
-    margin: 0;
-  }
-}
-
-.eligibility__table__list {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.eligibility__table__footer {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: $eligibilityTablePaddingH 0 0;
-  @include body_large_desktop;
-
-  .eligibility__table__footer__link {
-    @include body_standard_desktop;
-    margin-top: 0.625rem; //10px
-  }
-
-  a {
-    color: black;
-    margin-left: 0.625rem; //10px
-  }
-}
-
-.eligibility__row {
-  display: flex;
-  border-bottom: 1px solid $GREY_NEW;
-  align-items: center;
-  padding: 20px 0;
-
   @media (max-width: 772px) {
-    flex-direction: column;
-    gap: 16px;
-    text-align: center;
-  }
-
-  .eligibility__row__icon {
-    padding: 0 1.25rem; // 0 20px
-    font-size: 1.875rem; //30px
-    width: 1.875rem; //30px
-
-    .eligible {
-      color: $GREEN;
+    .eligibility__row {
+      flex-direction: column;
+      gap: 16px;
+      text-align: center;
     }
-    .ineligible {
-      color: $YELLOW;
-    }
-    .unknown {
-      color: $YELLOW;
-    }
-  }
-
-  .eligibility__row__info {
-    display: flex;
-    flex-direction: column;
-    flex-shrink: 0;
-    width: 320px;
-    padding-right: 1rem;
-    box-sizing: border-box;
-    gap: 10px;
-
-    @media (max-width: 772px) {
+    .eligibility__row__info {
       width: 100%;
     }
-  }
-
-  .eligibility__row__criteria {
-    @include eyebrow_small_desktop;
-  }
-
-  .eligibility__row__requirement {
-    @include body_standard_desktop;
-  }
-
-  .eligibility__row__userValue {
-    @include body_standard_desktop;
-    margin: 0 1.25rem; // 20px
-    box-sizing: border-box;
-    flex-grow: 1;
-
-    p {
-      margin: 0 0 0.625rem 0;
-    }
-
-    @media (max-width: 772px) {
+    .eligibility__row__userValue {
       margin: 0;
     }
   }
-}
 
-.eligibility__footer {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  margin: 2.625rem 0; //42px
-
-  .eligibility__footer__header {
-    @include h3_desktop;
-    margin: 0 0 $eligibilityTablePaddingH 0;
-    text-align: center;
+  .protections-on-next-page__print {
+    display: none;
+  }
+  .divider__print {
+    display: none;
   }
 }
 
 @media print {
-  .eligibility__result {
-    display: none;
-  }
-
-  .eligibility__table__container {
-    display: none;
-  }
-
-  .eligibility__table__container__print {
-    .eligibility__table {
-      border-top: 2px solid $GREY_NEW;
-      background-color: $WHITE;
+  #results-page {
+    .eligibility__result .covered-pill {
+      background-color: unset;
+      padding: unset;
+      text-decoration: underline;
+      text-underline-offset: 0.5rem;
+      color: $OFF_BLACK;
     }
 
-    .eligibility__table__header {
-      display: flex;
-      padding-bottom: $eligibilityTablePaddingH;
-      flex-direction: column;
-      gap: 10px;
-
-      .eligibility__table__header-title {
-        @include eyebrow_small_desktop;
+    .eligibility__row {
+      &:last-of-type {
+        border-bottom: unset;
       }
-
-      .eligibility__table__header-subtitle {
-        @include h3_desktop;
-      }
-    }
-
-    .eligibility__table__list {
-      margin: 0;
-      padding: 0;
-      list-style: none;
     }
 
     .eligibility__table__footer {
       display: none;
-      //display: flex;
-      flex-direction: column;
-      align-items: center;
-      padding: $eligibilityTablePaddingH 0 0;
-      @include body_large_desktop;
+    }
 
-      .eligibility__table__footer__link {
-        @include body_standard_desktop;
-        margin-top: 0.625rem; //10px
+    .protections-on-next-page__print {
+      @include h3_desktop;
+      text-align: center;
+    }
+
+    .content-box {
+      border: unset;
+      .accordion__chevron {
+        display: none;
       }
-
-      a {
+      .content-box__footer {
+        display: none;
+      }
+    }
+    .eligibility__row__icon,
+    .eligibility__icon {
+      svg {
         color: black;
-        margin-left: 0.625rem; //10px
       }
     }
 
-    .eligibility__row {
-      display: flex;
-      border-bottom: 1px solid $GREY_NEW;
-      align-items: center;
-      flex-direction: row;
-      text-align: left;
-
-      .eligibility__row__icon {
-        padding: 0 1.25rem; // 0 20px
-        font-size: 1.875rem; //30px
-        width: 1.875rem; //30px
-
-        .eligible {
-          color: $OFF_BLACK;
-        }
-        .ineligible {
-          color: $OFF_BLACK;
-        }
-        .unknown {
-          color: $OFF_BLACK;
-        }
-      }
-
-      .eligibility__row__info {
-        display: flex;
-        flex-direction: column;
-        flex-shrink: 0;
-        width: 320px;
-        padding-right: 1rem;
-        box-sizing: border-box;
-        gap: 10px;
-      }
-
-      .eligibility__row__criteria {
-        @include eyebrow_small_desktop;
-      }
-
-      .eligibility__row__requirement {
-        @include body_standard_desktop;
-      }
-
-      .eligibility__row__userValue {
-        @include body_standard_desktop;
-        margin: 0 1.25rem; // 20px
-        box-sizing: border-box;
-        flex-grow: 1;
-
-        p {
-          margin: 0 0 0.625rem 0;
-        }
-
-        .jfcl-link {
-          display: none;
-        }
-      }
-    }
-  }
-}
-
-.next-step {
-  --icon-size: 2.75rem; // 44px;
-  --icon-margin: 1.5rem; // 24px;
-
-  .eligibility__icon {
-    font-size: 1.875rem; //30px
-    margin-right: var(--icon-margin);
-
-    .eligible {
-      color: $GREEN;
-    }
-    .ineligible {
-      color: $RED;
-    }
-    .unknown {
-      color: $YELLOW;
+    .divider__print {
+      border-bottom: 1px solid black;
     }
 
-    svg {
-      width: var(--icon-size);
-      height: var(--icon-size);
+    .eligibility__footer {
+      display: none;
     }
-  }
-  .accordion__content {
-    margin-left: calc(var(--icon-size) + var(--icon-margin));
   }
 }

--- a/src/Components/Pages/Results/Results.scss
+++ b/src/Components/Pages/Results/Results.scss
@@ -214,6 +214,7 @@ $eligibilityTablePaddingH: 36px;
     }
 
     .content-box {
+      margin-top: unset;
       border: unset;
       .accordion__chevron {
         display: none;

--- a/src/Components/Pages/Results/Results.scss
+++ b/src/Components/Pages/Results/Results.scss
@@ -214,7 +214,6 @@ $eligibilityTablePaddingH: 36px;
     }
 
     .content-box {
-      margin-top: unset;
       border: unset;
       .accordion__chevron {
         display: none;

--- a/src/Components/Pages/Results/Results.tsx
+++ b/src/Components/Pages/Results/Results.tsx
@@ -71,31 +71,30 @@ export const Results: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const handlePrintAccordions = (event: MediaQueryListEvent) => {
-    let accordions: NodeListOf<HTMLDetailsElement>;
-    if (event.matches) {
-      accordions = document.body.querySelectorAll("details:not([open])");
-      accordions.forEach((e) => {
-        e.setAttribute("open", "");
-        e.dataset.wasclosed = "";
-      });
-    } else {
-      accordions = document.body.querySelectorAll("details[data-wasclosed]");
-      accordions.forEach((e) => {
-        e.removeAttribute("open");
-        delete e.dataset.wasclosed;
-      });
-    }
+  const openAccordionsPrint = () => {
+    const accordions: NodeListOf<HTMLDetailsElement> =
+      document.body.querySelectorAll("details:not([open])");
+    accordions.forEach((e) => {
+      e.setAttribute("open", "");
+      e.dataset.wasclosed = "";
+    });
+  };
+
+  const closeAccordionsPrint = () => {
+    const accordions: NodeListOf<HTMLDetailsElement> =
+      document.body.querySelectorAll("details[data-wasclosed]");
+    accordions.forEach((e) => {
+      e.removeAttribute("open");
+      delete e.dataset.wasclosed;
+    });
   };
 
   useEffect(() => {
-    window
-      .matchMedia("print")
-      .addEventListener("change", handlePrintAccordions);
+    window.addEventListener("beforeprint", openAccordionsPrint);
+    window.addEventListener("afterprint", closeAccordionsPrint);
     return () => {
-      window
-        .matchMedia("print")
-        .removeEventListener("change", handlePrintAccordions);
+      window.removeEventListener("beforeprint", openAccordionsPrint);
+      window.removeEventListener("afterprint", closeAccordionsPrint);
     };
   }, []);
 

--- a/src/Components/Pages/content-page.scss
+++ b/src/Components/Pages/content-page.scss
@@ -12,10 +12,6 @@ $eligibilityTablePaddingH: 36px;
 
   padding-left: 3rem; // 48px
   padding-right: 3rem; // 48px
-  @media (max-width: 772px) {
-    padding-left: 1.5rem; // 24px
-    padding-right: 1.5rem; // 24px
-  }
 }
 
 .headline-section {
@@ -37,38 +33,17 @@ $eligibilityTablePaddingH: 36px;
     .headline-section__page-type {
       @include eyebrow_large_desktop;
       padding-top: 30px;
-      @media print {
-        display: none;
-      }
-    }
-    .headline-section__page-type__print {
-      @include eyebrow_large_desktop;
-      @media screen {
-        display: none;
-      }
     }
 
     .headline-section__title {
       display: flex;
       flex-direction: column;
       gap: 4px;
-      @media print {
-        margin: 24px 0;
-      }
     }
 
     .headline-section__subtitle {
       @include body_large_desktop;
       margin-top: 1.125rem; // 18px
-      @media print {
-        margin-bottom: 0;
-      }
-    }
-
-    .jfcl-button {
-      @media print {
-        display: none;
-      }
     }
   }
 }
@@ -81,5 +56,33 @@ $eligibilityTablePaddingH: 36px;
     max-width: $contentBoxWidth;
     display: flex;
     flex-direction: column;
+  }
+}
+
+@media screen {
+  .headline-section,
+  .content-section {
+    @media (max-width: 772px) {
+      padding-left: 1.5rem; // 24px
+      padding-right: 1.5rem; // 24px
+    }
+  }
+  .headline-section__address__print {
+    @media screen {
+      display: none;
+    }
+  }
+}
+@media print {
+  .headline-section,
+  .content-section {
+    background-color: unset;
+    border-bottom: unset;
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+
+  .headline-section__address__print {
+    @include body_large_desktop;
   }
 }

--- a/src/mixins.scss
+++ b/src/mixins.scss
@@ -8,7 +8,7 @@
 }
 
 @mixin h3_desktop {
-  font-size: 36px;
+  font-size: 2.25rem; // 36px
   font-style: normal;
   font-weight: 600;
   line-height: 100%; /* 36px */


### PR DESCRIPTION
Updates the styles for printing the results page (guide pages to follow in separate PR)

This ones has a lot of reorganization of styles (lots of moving around, and changed nested), and also some minor additions to component (eg. adding print dividers after content boxes) that created big diffs where there aren't real changes.

All closed accordions are automatically opened for the print and then reset back to preexisting state afterwards. 

I had to make some changes from the design files to keep everything on the page. In particular, the text was too big on the print page, so I also changed the base font size when printing down to 12px and that helped. Will review with Corey, but good to merge this in first since there are so many changes it'll make it hard to do other things without lots of merge conflicts. 

Here's an example of a print ed result: [gce-result-print.pdf](https://github.com/user-attachments/files/18201382/gce-result-print.pdf)


might add `page-break-after: always;` on contentbox, waiting for corey feedback

[sc-15986]