### PR TITLE
hide rent input increment buttons, prevent scroll changing numbers

### DIFF
--- a/src/Components/Pages/Form/Form.scss
+++ b/src/Components/Pages/Form/Form.scss
@@ -25,6 +25,12 @@
 
   #rent-input {
     max-width: 19.375rem; // 310px
+    &::-webkit-inner-spin-button,
+    ::-webkit-outer-spin-button {
+      appearance: none;
+      margin: 0;
+    }
+    appearance: textfield;
   }
 
   .form__buttons {

--- a/src/Components/Pages/Form/Form.tsx
+++ b/src/Components/Pages/Form/Form.tsx
@@ -165,6 +165,12 @@ export const Form: React.FC = () => {
                 name="rent"
                 value={localFields["rent"] || ""}
                 onChange={handleInputChange}
+                onWheel={(e) => {
+                  // prevents scroll incrementing value
+                  e.currentTarget.blur();
+                  e.stopPropagation();
+                  setTimeout(() => e.currentTarget.focus(), 0);
+                }}
               />
             </FormStep>
 


### PR DESCRIPTION
The rent number input had the increment "spinner" arrows and if you were focused on the input and scrolled it would change the number. This hides it (webkit and firefox) and disables that scroll behavior

[sc-15989]