### PR TITLE
Add share buttons to result/guide pages 

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "format": "prettier --write --ignore-unknown \"src/**/*\""
   },
   "dependencies": {
-    "@justfixnyc/component-library": "0.53.5",
+    "@justfixnyc/component-library": "0.53.7",
     "@justfixnyc/geosearch-requester": "^1.0.3-alpha.0",
     "@rollbar/react": "^0.12.0-beta",
     "react": "^18.3.1",

--- a/src/Components/CheckPlusIcon.tsx
+++ b/src/Components/CheckPlusIcon.tsx
@@ -14,21 +14,21 @@ export const CheckPlusIcon: React.FC<{
     <path
       d="M5 17.4L13.4 25.8L31.4 7.79999"
       stroke="currentcolor"
-      stroke-width="5"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeWidth="5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
     />
     <path
       d="M32 16.6L32 26.6"
       stroke="currentcolor"
-      stroke-width="4"
-      stroke-linecap="round"
+      strokeWidth="4"
+      strokeLinecap="round"
     />
     <path
       d="M37 21.6L27 21.6"
       stroke="currentcolor"
-      stroke-width="4"
-      stroke-linecap="round"
+      strokeWidth="4"
+      strokeLinecap="round"
     />
   </svg>
 );

--- a/src/Components/Pages/PortfolioSize/PortfolioSize.tsx
+++ b/src/Components/Pages/PortfolioSize/PortfolioSize.tsx
@@ -23,9 +23,14 @@ import {
 import "./PortfolioSize.scss";
 import { InfoBox } from "../../InfoBox/InfoBox";
 import { Header } from "../../Header/Header";
+import { ShareButtons } from "../../ShareButtons/ShareButtons";
 
 // const LOOM_EMBED_URL =
 //   "https://www.loom.com/embed/cef3632773a14617a0e8ec407c77e513?sid=93a986f7-ccdc-4048-903c-974fed826119";
+
+const EMAIL_SUBJECT =
+  "Good Cause NYC | Find out if your landlord owns other apartments";
+const EMAIL_BODY = "...";
 
 export const PortfolioSize: React.FC = () => {
   const { address, fields } = useLoaderData() as {
@@ -62,6 +67,14 @@ export const PortfolioSize: React.FC = () => {
             minutes.
           </div>
         )}
+        <ShareButtons
+          buttonsInfo={[
+            ["bookmark", "Bookmark this page"],
+            ["email", "Email this page"],
+          ]}
+          emailSubject={EMAIL_SUBJECT}
+          emailBody={EMAIL_BODY}
+        />
       </Header>
 
       <div className="content-section">

--- a/src/Components/Pages/RentStabilization/RentStabilization.tsx
+++ b/src/Components/Pages/RentStabilization/RentStabilization.tsx
@@ -9,6 +9,11 @@ import JFCLLinkExternal from "../../JFCLLinkExternal";
 import { BackLink } from "../../JFCLLinkInternal";
 import { Address } from "../Home/Home";
 import { Header } from "../../Header/Header";
+import { ShareButtons } from "../../ShareButtons/ShareButtons";
+
+const EMAIL_SUBJECT =
+  "Good Cause NYC | Find out if your apartment is rent stabilized";
+const EMAIL_BODY = "...";
 
 export const RentStabilization: React.FC = () => {
   const { address } = useLoaderData() as {
@@ -21,7 +26,16 @@ export const RentStabilization: React.FC = () => {
         title="Find out if your apartment is rent stabilized"
         address={address}
         isGuide
-      />
+      >
+        <ShareButtons
+          buttonsInfo={[
+            ["bookmark", "Bookmark this page"],
+            ["email", "Email this page"],
+          ]}
+          emailSubject={EMAIL_SUBJECT}
+          emailBody={EMAIL_BODY}
+        />
+      </Header>
 
       <div className="content-section">
         <div className="content-section__content"></div>

--- a/src/Components/Pages/Results/Results.scss
+++ b/src/Components/Pages/Results/Results.scss
@@ -200,14 +200,16 @@ $eligibilityTablePaddingH: 36px;
       color: $OFF_BLACK;
     }
 
+    .share-button__container,
+    .eligibility__table__footer,
+    .share-footer {
+      display: none;
+    }
+
     .eligibility__row {
       &:last-of-type {
         border-bottom: unset;
       }
-    }
-
-    .eligibility__table__footer {
-      display: none;
     }
 
     .protections-on-next-page__print {
@@ -217,9 +219,7 @@ $eligibilityTablePaddingH: 36px;
 
     .content-box {
       border: unset;
-      .accordion__chevron {
-        display: none;
-      }
+      .accordion__chevron,
       .content-box__footer {
         display: none;
       }
@@ -232,10 +232,6 @@ $eligibilityTablePaddingH: 36px;
 
     .divider__print {
       border-bottom: 1px solid black;
-    }
-
-    .share-footer {
-      display: none;
     }
   }
 }

--- a/src/Components/Pages/Results/Results.tsx
+++ b/src/Components/Pages/Results/Results.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { Link, useLoaderData, useSearchParams } from "react-router-dom";
 import { Button, Icon } from "@justfixnyc/component-library";
 
@@ -30,8 +30,9 @@ import {
   UniversalProtections,
 } from "../../KYRContent/KYRContent";
 import { Header } from "../../Header/Header";
-import "./Results.scss";
 import { CheckPlusIcon } from "../../CheckPlusIcon";
+import { ShareButtons } from "../../ShareButtons/ShareButtons";
+import "./Results.scss";
 
 export const Results: React.FC = () => {
   const { address, fields, user } = useLoaderData() as {
@@ -46,6 +47,10 @@ export const Results: React.FC = () => {
   const criteriaDetails = useCriteriaDetails(fields, bldgData);
   const criteriaResults = getCriteriaResults(criteriaDetails);
   const coverageResult = getCoverageResult(fields, criteriaResults);
+
+  const headlineRef = useRef<HTMLSpanElement>(null);
+  const EMAIL_SUBJECT = "Good Cause NYC | Your Coverage Result";
+  const EMAIL_BODY = headlineRef?.current?.textContent;
 
   useEffect(() => {
     // save session state in params
@@ -109,7 +114,10 @@ export const Results: React.FC = () => {
       <Header
         title={
           bldgData && coverageResult ? (
-            <CoverageResultHeadline result={coverageResult} />
+            <CoverageResultHeadline
+              result={coverageResult}
+              headlineRef={headlineRef}
+            />
           ) : (
             "Loading your results..."
           )
@@ -124,6 +132,18 @@ export const Results: React.FC = () => {
         )}
         {isLoading && (
           <div className="data__loading">Loading your results...</div>
+        )}
+
+        {bldgData && coverageResult && (
+          <ShareButtons
+            buttonsInfo={[
+              ["email", "Email coverage"],
+              ["download", "Download coverage"],
+              ["print", "Print coverage"],
+            ]}
+            emailSubject={EMAIL_SUBJECT}
+            emailBody={EMAIL_BODY}
+          />
         )}
 
         {bldgData && <CriteriaTable criteria={criteriaDetails} />}
@@ -385,47 +405,55 @@ const getCoverageResult = (
 
 const CoverageResultHeadline: React.FC<{
   result: CoverageResult;
-}> = ({ result }) => {
+  headlineRef: React.RefObject<HTMLSpanElement>;
+}> = ({ result, headlineRef }) => {
+  let headlineContent = <></>;
   switch (result) {
     case "UNKNOWN":
-      return (
-        <span>
+      headlineContent = (
+        <>
           Your apartment{" "}
           <span className="coverage-pill yellow">might be covered</span> by Good
           Cause Eviction
-        </span>
+        </>
       );
+      break;
     case "NOT_COVERED":
-      return (
-        <span>
+      headlineContent = (
+        <>
           Your apartment is likely{" "}
           <span className="coverage-pill orange">not covered</span> by Good
           Cause Eviction
-        </span>
+        </>
       );
+      break;
     case "RENT_STABILIZED":
-      return (
-        <span>
+      headlineContent = (
+        <>
           Your apartment is protected by{" "}
           <span className="coverage-pill green">rent stabilization</span>, which
           provides stronger protections than Good Cause Eviction
-        </span>
+        </>
       );
+      break;
     case "COVERED":
-      return (
-        <span>
+      headlineContent = (
+        <>
           Your apartment is likely{" "}
           <span className="coverage-pill green">covered</span> by Good Cause
           Eviction
-        </span>
+        </>
       );
+      break;
     case "NYCHA":
-      return (
-        <span>
+      headlineContent = (
+        <>
           Your apartment is part of{" "}
           <span className="coverage-pill green">NYCHA</span>, which provides
           stronger protections than Good Cause Eviction
-        </span>
+        </>
       );
+      break;
   }
+  return <span ref={headlineRef}>{headlineContent}</span>;
 };

--- a/src/Components/ShareButtons/ShareButtons.scss
+++ b/src/Components/ShareButtons/ShareButtons.scss
@@ -1,0 +1,21 @@
+.share-button__container {
+  display: flex;
+  gap: 1.5rem;
+  margin-top: 3rem;
+
+  button.share-button {
+    background: unset;
+    border: unset;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+  .share-button svg {
+    margin-right: 0.5rem;
+  }
+}
+
+@media print {
+  .share-button__container {
+    display: none;
+  }
+}

--- a/src/Components/ShareButtons/ShareButtons.tsx
+++ b/src/Components/ShareButtons/ShareButtons.tsx
@@ -1,0 +1,71 @@
+import { Icon } from "@justfixnyc/component-library";
+import "./ShareButtons.scss";
+
+type ShareButtonType = "email" | "download" | "print" | "bookmark";
+type ShareButtonsProps = {
+  buttonsInfo: [ShareButtonType, string][];
+  emailSubject?: string | null;
+  emailBody?: string | null;
+};
+
+export const ShareButtons: React.FC<ShareButtonsProps> = ({
+  buttonsInfo,
+  emailSubject,
+  emailBody,
+}) => {
+  const mailtoLink =
+    `mailto:` + emailSubject
+      ? `&subject=${emailSubject}`
+      : "" + emailBody
+      ? `&subject=${emailBody}`
+      : "";
+  const emailButton = (x: string) => (
+    <a
+      href={mailtoLink}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="share-button jfcl-link"
+    >
+      <Icon icon="envelope" type="regular" />
+      {x}
+    </a>
+  );
+
+  const downloadButton = (x: string) => (
+    <button onClick={window.print} className="share-button jfcl-link">
+      <Icon icon="download" type="regular" />
+      {x}
+    </button>
+  );
+
+  const printButton = (x: string) => (
+    <button onClick={window.print} className="share-button jfcl-link">
+      <Icon icon="print" type="regular" />
+      {x}
+    </button>
+  );
+
+  const bookmarkButton = (x: string) => (
+    <button onClick={() => {}} className="share-button jfcl-link">
+      <Icon icon="bookmark" type="regular" />
+      {x}
+    </button>
+  );
+
+  const buttonElements = {
+    email: emailButton,
+    download: downloadButton,
+    print: printButton,
+    bookmark: bookmarkButton,
+  };
+
+  return (
+    <div className="share-button__container">
+      {buttonsInfo.map((b) => {
+        const buttonFun = buttonElements[b[0]];
+        const message = b[1];
+        return buttonFun(message);
+      })}
+    </div>
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -450,10 +450,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@justfixnyc/component-library@0.53.5":
-  version "0.53.5"
-  resolved "https://registry.yarnpkg.com/@justfixnyc/component-library/-/component-library-0.53.5.tgz#5df3b76f00746c07165a84368f9fdc06ea4a5363"
-  integrity sha512-EciGdYItSA9PDlFQiKFpgB3eaD/ecR7EoGmKBcxWdoZveKt+y0zpT4Ljpz3pvjgQHFjdAfmXa+RE5Ib5+NTiIQ==
+"@justfixnyc/component-library@0.53.7":
+  version "0.53.7"
+  resolved "https://registry.yarnpkg.com/@justfixnyc/component-library/-/component-library-0.53.7.tgz#b715b78aaca903485f5cc8341477ccbeb2843c18"
+  integrity sha512-AGKGu4tcd/gdZaRQVCNLti+ZQ99h1Kq+v1+Xa9D4baa8+PJNZqZWzguPm8JwKDwN833rHFgqrqRjp5ogmmQhsw==
   dependencies:
     "@awesome.me/kit-dd32553919" "^1.0.13"
     "@babel/runtime" "^7.12.5"


### PR DESCRIPTION
Adds the print/email/download/bookmark buttons to the top of the result and guide pages. 

The email content and the behavior of the bookmark are still TBD.

[sc-15974]