### PR TITLE
WIP: reduce all font weights by 100, better visual parity with figma

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -63,7 +63,7 @@
   text-align: center;
   font-size: 0.875rem; // 14px
   font-style: normal;
-  font-weight: 600;
+  font-weight: 500;
   line-height: 100%; // 14px
   letter-spacing: 1.12px;
   text-transform: uppercase;

--- a/src/Components/ContentBox/ContentBox.scss
+++ b/src/Components/ContentBox/ContentBox.scss
@@ -73,7 +73,7 @@ $videoEmbedW: 623px;
       max-width: $contentPWidth;
       margin: 0;
       &.bold {
-        font-weight: 700;
+        font-weight: 600;
       }
     }
 

--- a/src/Components/InfoBox/InfoBox.scss
+++ b/src/Components/InfoBox/InfoBox.scss
@@ -25,7 +25,7 @@
     flex: 1;
     @include small_text_desktop;
     .bold {
-      font-weight: 600;
+      font-weight: 500;
     }
   }
 }

--- a/src/Components/Pages/PortfolioSize/PortfolioSize.scss
+++ b/src/Components/Pages/PortfolioSize/PortfolioSize.scss
@@ -15,7 +15,7 @@
       align-items: center;
       list-style: none;
       @include body_standard_desktop;
-      font-weight: 600;
+      font-weight: 500;
       cursor: pointer;
 
       .acris-links__pill {
@@ -31,7 +31,7 @@
       padding: 0 1.5rem 1.125rem 1.5rem; // 0 24px 18px 24px
 
       p {
-        font-weight: 600;
+        font-weight: 500;
         margin-top: 1.875rem; // 30px
       }
       ul {

--- a/src/Components/ProgressBar/ProgressBar.scss
+++ b/src/Components/ProgressBar/ProgressBar.scss
@@ -9,7 +9,7 @@
 
   .progress-bar__step {
     display: flex;
-    font-weight: 500;
+    font-weight: 400;
 
     span,
     a {
@@ -30,7 +30,7 @@
       margin-right: 0.38rem;
       font-family: "Degular Text";
       font-size: 0.875rem;
-      font-weight: 600;
+      font-weight: 500;
       letter-spacing: -0.00963rem;
     }
 

--- a/src/Components/TopBar/TopBar.scss
+++ b/src/Components/TopBar/TopBar.scss
@@ -33,7 +33,7 @@
       margin: 0;
       font-family: "Degular Display";
       font-size: 1.5rem;
-      font-weight: 500;
+      font-weight: 400;
       line-height: 100%; /* 1.5rem */
       letter-spacing: 0.045rem;
     }
@@ -44,7 +44,7 @@
     border-right: 1px solid $OFF_WHITE_100;
     padding: 1.5rem 2.25rem;
     font-size: 1.125rem;
-    font-weight: 500;
+    font-weight: 400;
     line-height: 100%; /* 1.125rem */
     letter-spacing: 0.0225rem;
     a {
@@ -63,7 +63,7 @@
     padding: 1.5rem;
     font-family: "Degular Display";
     font-size: 1.125rem;
-    font-weight: 500;
+    font-weight: 400;
     letter-spacing: 0.03375rem;
   }
 

--- a/src/mixins.scss
+++ b/src/mixins.scss
@@ -1,7 +1,9 @@
+// All font weights being adjusted down 100 since they visually don't match between website and figma
+
 @mixin body_standard_desktop {
   font-family: "Degular", Arial, Helvetica, sans-serif;
   font-style: normal;
-  font-weight: 500;
+  font-weight: 400;
   font-size: 1.125rem; // 18px
   line-height: 120%; // 21.6px
   letter-spacing: 0.54px;
@@ -10,22 +12,22 @@
 @mixin h3_desktop {
   font-size: 2.25rem; // 36px
   font-style: normal;
-  font-weight: 600;
+  font-weight: 500;
   line-height: 100%; /* 36px */
 }
 
 @mixin h4_desktop {
   font-size: 1.5rem; // 24px
   font-style: normal;
-  font-weight: 500;
+  font-weight: 400;
   line-height: 120%;
 }
 
 @mixin page_header {
-  font-family: Degular;
+  font-family: "Degular", Arial, Helvetica, sans-serif;
   font-size: 3.25rem; // 52px;
   font-style: normal;
-  font-weight: 500;
+  font-weight: 400;
   line-height: 100%; /* 52px */
   letter-spacing: 1.56px;
 }
@@ -33,7 +35,7 @@
 @mixin body_large_desktop {
   font-family: "Degular", Arial, Helvetica, sans-serif;
   font-style: normal;
-  font-weight: 500;
+  font-weight: 400;
   font-size: 1.5rem; // 24px
   line-height: 120%; // 28.8px
   letter-spacing: 0.72px;
@@ -42,7 +44,7 @@
 @mixin small_text_desktop {
   font-family: "Degular", Arial, Helvetica, sans-serif;
   font-style: normal;
-  font-weight: 500;
+  font-weight: 400;
   font-size: 0.875rem; // 14px
   line-height: 130%; // 28.8px
   letter-spacing: 0.42px;
@@ -52,7 +54,7 @@
   font-family: "Suisse Int'l Mono";
   font-size: 1rem; // 16px;
   font-style: normal;
-  font-weight: 400;
+  font-weight: 300;
   line-height: 115%; /* 18.4px */
   letter-spacing: 0.48px;
   text-transform: uppercase;
@@ -62,7 +64,7 @@
   font-family: "Suisse Int'l Mono";
   font-size: 1.125rem; // 18px
   font-style: normal;
-  font-weight: 400;
+  font-weight: 300;
   line-height: 115%; /* 20.7px */
   letter-spacing: 0.54px;
   text-transform: uppercase;


### PR DESCRIPTION
All the font weights were not looking correct on the website compared to figma mocks, so reducing them all by 100 which looks more like the original intention. 

[sc-16052]