### PR TITLE
update sorting of related properties on portfolio size page

### DIFF
--- a/src/Components/Pages/PortfolioSize/PortfolioSize.tsx
+++ b/src/Components/Pages/PortfolioSize/PortfolioSize.tsx
@@ -15,8 +15,8 @@ import { AcrisDocument, BuildingData } from "../../../types/APIDataTypes";
 import {
   acrisDocTypeFull,
   closeAccordionsPrint,
+  getPrioritizeBldgs,
   openAccordionsPrint,
-  prioritizeBldgs,
   urlAcrisBbl,
   urlAcrisDoc,
   urlCountyClerkBbl,
@@ -131,7 +131,7 @@ export const PortfolioSize: React.FC = () => {
             title="Find other buildings your landlord might own"
             step={2}
           >
-            {!!bldgData?.related_properties && (
+            {bldgData && !!bldgData?.related_properties && (
               <>
                 <p>
                   Review documents below to find your landlord’s name or
@@ -141,15 +141,17 @@ export const PortfolioSize: React.FC = () => {
                 <br />
               </>
             )}
-            <p>
-              {`Your building has ${bldgData?.unitsres} apartments. You only need to confirm that your ` +
-                `landlord owns ${10 - bldgData!.unitsres} additional ${
-                  10 - bldgData!.unitsres == 1 ? "apartment" : "apartments"
-                } across other buildings.`}
-            </p>
+            {bldgData?.unitsres && (
+              <p>
+                {`Your building has ${bldgData.unitsres} apartments. You only need to confirm that your ` +
+                  `landlord owns ${10 - bldgData.unitsres} additional ${
+                    10 - bldgData.unitsres == 1 ? "apartment" : "apartments"
+                  } across other buildings.`}
+              </p>
+            )}
             <VideoEmbed url="" />
             <div className="content-box__section__related-buildings">
-              {!!bldgData?.related_properties ? (
+              {bldgData?.related_properties ? (
                 <>
                   {isLoading && <>Loading document links...</>}
                   <AcrisAccordions {...bldgData} />
@@ -297,6 +299,10 @@ const FindOtherBuildings: React.FC = () => {
 export const AcrisAccordions: React.FC<BuildingData> = (props) => {
   const INIT_DISPLAY = 5;
   const LOAD_MORE_AMOUNT = 5;
+
+  // Generate a sort function that takes into account how many additional units
+  // we need to find
+  const prioritizeBldgs = getPrioritizeBldgs(10 - props.unitsres);
 
   // TODO: decide how to handle these cases, for now exclude. might also want to exclude if no acris_docs, but for now leave in.
   const relatedProperties = props.related_properties

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -81,11 +81,38 @@ export const formatDistance = (distance_ft: number): string => {
   }
 };
 
-export const prioritizeBldgs = (a: RelatedProperty, b: RelatedProperty) => {
+const prioritizeBldgsWithUnits = (
+  a: RelatedProperty,
+  b: RelatedProperty,
+  unitsNeeded: number
+) => {
+  if (a.acris_docs.length !== b.acris_docs.length)
+    return a.acris_docs.length ? -1 : 1;
+
+  if (a.match_ownername !== b.match_ownername)
+    return a.match_ownername ? -1 : 1;
+
+  if (a.match_multidoc !== b.match_multidoc) return a.match_multidoc ? -1 : 1;
+
   if (a.wow_match_name !== b.wow_match_name) return a.wow_match_name ? -1 : 1;
+
   if (a.wow_match_bizaddr_unit !== b.wow_match_bizaddr_unit)
     return a.wow_match_bizaddr_unit ? -1 : 1;
+
+  if (
+    unitsNeeded > 0 &&
+    a.unitsres >= unitsNeeded !== b.unitsres >= unitsNeeded
+  )
+    return a.unitsres >= unitsNeeded ? -1 : 1;
+
   return b.distance_ft - a.distance_ft;
+};
+
+// Return the above function with the additional argument pre-filled so we can
+// incorporate the number of additional units needed into the sort logic
+export const getPrioritizeBldgs = (unitsNeeded: number) => {
+  return (a: RelatedProperty, b: RelatedProperty) =>
+    prioritizeBldgsWithUnits(a, b, unitsNeeded);
 };
 
 export const urlCountyClerkBbl = (bbl: string) => {

--- a/src/types/APIDataTypes.ts
+++ b/src/types/APIDataTypes.ts
@@ -35,7 +35,7 @@ export type BuildingData = {
   end_421a: string;
   end_j51: string;
   acris_docs: AcrisDocument[];
-  related_properties: RelatedProperty[] | null;
+  related_properties: RelatedProperty[];
 };
 
 // Tenants2 API


### PR DESCRIPTION
For the sorting, I've added some addition criteria to sort by:
- whether there are acris doc links, 
- number of units in the property compared to how many additional units the user needs to find, 
- whether the property shares the exact same ownername in DOF records
- whether the property is listed alongside the search address in a multi-BBL acris document

Also, in working on this I was reminded of soe annoying type issues with the WOW api data so made a small adjustment (mostly on the wow side https://github.com/JustFixNYC/who-owns-what/pull/971/commits/08acf27edafd6afc2d0db8721f1a094f662a651d). It was confusing because there were NULLs instead of arrays when there was no data, but now it'll be empty arrays.

[sc-15839]