### PR TITLE
address search bar highlights existing text when focused

### DIFF
--- a/src/Components/GeoSearchInput/GeoSearchInput.scss
+++ b/src/Components/GeoSearchInput/GeoSearchInput.scss
@@ -8,6 +8,10 @@
     margin-bottom: 2px;
     &.jfcl-dropdown__control--is-focused {
       margin-bottom: 0;
+
+      .jfcl-dropdown__single-value {
+        background-color: $BLUE_50;
+      }
     }
   }
 

--- a/src/Components/GeoSearchInput/GeoSearchInput.scss
+++ b/src/Components/GeoSearchInput/GeoSearchInput.scss
@@ -11,6 +11,7 @@
 
       .jfcl-dropdown__single-value {
         background-color: $BLUE_50;
+        width: fit-content;
       }
     }
   }


### PR DESCRIPTION
When address bar has text in it already and is focused it highlights the existing text to make it clear that if you start typing it will clear all of that. react-select makes it really tricky to actually access the input element to be able to use `input.select()` to actually select it, but this visual highlighting works.