### PR TITLE
clear session on return to home page

### DIFF
--- a/src/Components/Pages/Home/Home.tsx
+++ b/src/Components/Pages/Home/Home.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { useRollbar } from "@rollbar/react";
 import { Button } from "@justfixnyc/component-library";
@@ -26,7 +26,8 @@ export type Address = {
 export const Home: React.FC = () => {
   const navigate = useNavigate();
   const [, setUser] = useSessionStorage<GCEUser>("user");
-  const [address, setAddress] = useSessionStorage<Address>("address");
+  const [address, setAddress, removeAddress] =
+    useSessionStorage<Address>("address");
   const [, , removeFormFields] = useSessionStorage<FormFields>("fields");
   const [lastStepReached, setLastStepReached] =
     useSessionStorage<ProgressStep>("lastStepReached");
@@ -34,6 +35,13 @@ export const Home: React.FC = () => {
   const [inputInvalid, setInputInvalid] = useState(false);
   const { trigger } = useSendGceData();
   const rollbar = useRollbar();
+
+  useEffect(() => {
+    removeAddress();
+    removeFormFields();
+    setLastStepReached(ProgressStep.Home);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleAddressSearch = async () => {
     if (!geoAddress) {
@@ -73,7 +81,6 @@ export const Home: React.FC = () => {
             Eviction law in NYC
           </>
         }
-        address={address}
         lastStepReached={lastStepReached}
       >
         <div className="geo-search-form">


### PR DESCRIPTION
Once you've selected an address and progresses through some steps, if you return to the home page (eg. "new search") it will clear your previous address and form responses from state. The old address will not appear in the progress bar and future steps won't be links. 

https://www.loom.com/share/253fac8fd70048428da4e833c4ee8ba8?sid=d0f6cd91-3987-4edd-b47b-9d61ef3e7dda

TBD on whether we will leave the behavior that the previously searched address appears as a default dropdown option on the cleared home page - maybe this is useful.

[sc-16118]