### PR TITLE
add privacy and terms of use pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
     "format": "prettier --write --ignore-unknown \"src/**/*\""
   },
   "dependencies": {
+    "@contentful/rich-text-react-renderer": "^16.0.1",
     "@justfixnyc/component-library": "0.53.9",
     "@justfixnyc/geosearch-requester": "^1.0.3-alpha.0",
     "@rollbar/react": "^0.12.0-beta",
+    "contentful": "^11.4.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,8 @@ import { TenantRights } from "./Components/Pages/TenantRights/TenantRights";
 import { TopBar } from "./Components/TopBar/TopBar";
 import { NetworkError } from "./api/error-reporting";
 import "./App.scss";
+import { PrivacyPolicy } from "./Components/Pages/Legal/PrivacyPolicy";
+import { TermsOfUse } from "./Components/Pages/Legal/TermsOfUse";
 
 const Layout = () => {
   return (
@@ -128,6 +130,8 @@ const router = createBrowserRouter(
         loader={LoadURLSession}
       />
       <Route path="tenant_rights" element={<TenantRights />} />
+      <Route path="privacy_policy" element={<PrivacyPolicy />} />
+      <Route path="terms_of_use" element={<TermsOfUse />} />
       <Route path="api_docs" element={<APIDocs />} />
       <Route path="*" element={<Home />} />
     </Route>

--- a/src/Components/Footer/Footer.tsx
+++ b/src/Components/Footer/Footer.tsx
@@ -11,7 +11,7 @@ export const Footer: React.FC = () => (
       </div>
       <div className="footer__legal_pages">
         <a
-          href="https://www.justfix.org/privacy-policy"
+          href="privacy_policy"
           target="_blank"
           rel="noopener noreferrer"
           className="jfcl-link"
@@ -19,7 +19,7 @@ export const Footer: React.FC = () => (
           Privacy Policy
         </a>
         <a
-          href="https://www.justfix.org/terms-of-use"
+          href="terms_of_use"
           target="_blank"
           rel="noopener noreferrer"
           className="jfcl-link"

--- a/src/Components/Pages/Legal/Legal.scss
+++ b/src/Components/Pages/Legal/Legal.scss
@@ -1,0 +1,36 @@
+@import "../../../mixins.scss";
+
+#privacy-policy-page,
+#terms-of-use-page {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5 {
+    u {
+      text-decoration: none;
+    }
+  }
+
+  h1 {
+    @include page_header;
+    font-size: 2.5rem;
+    font-weight: 600;
+  }
+  h2 {
+    @include h3_desktop;
+    font-size: 2rem;
+  }
+  h3 {
+    @include h4_desktop;
+  }
+  h4 {
+    @include body_large_desktop;
+  }
+  h5 {
+    @include body_standard_desktop;
+  }
+  p {
+    @include body_standard_desktop;
+  }
+}

--- a/src/Components/Pages/Legal/PrivacyPolicy.tsx
+++ b/src/Components/Pages/Legal/PrivacyPolicy.tsx
@@ -8,7 +8,7 @@ export const PrivacyPolicy: React.FC = () => {
     <div id="privacy-policy-page">
       <Header
         title="Privacy policy"
-        subtitle="Last modified: May 13, 2024"
+        subtitle="Last modified: Jan 24, 2025"
         showProgressBar={false}
       />
 

--- a/src/Components/Pages/Legal/PrivacyPolicy.tsx
+++ b/src/Components/Pages/Legal/PrivacyPolicy.tsx
@@ -1,0 +1,22 @@
+import { ContentfulPage } from "../../../contentful/ContentfulPage";
+import { Header } from "../../Header/Header";
+import privacyPolicy from "../../../data/privacy-policy.en.json";
+import "./Legal.scss";
+
+export const PrivacyPolicy: React.FC = () => {
+  return (
+    <div id="privacy-policy-page">
+      <Header
+        title="Privacy policy"
+        subtitle="Last modified: May 13, 2024"
+        showProgressBar={false}
+      />
+
+      <div className="content-section">
+        <div className="content-section__content">
+          <ContentfulPage pageFields={privacyPolicy} />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/Components/Pages/Legal/TermsOfUse.tsx
+++ b/src/Components/Pages/Legal/TermsOfUse.tsx
@@ -1,0 +1,22 @@
+import { ContentfulPage } from "../../../contentful/ContentfulPage";
+import { Header } from "../../Header/Header";
+import privacyPolicy from "../../../data/terms-of-use.en.json";
+import "./Legal.scss";
+
+export const TermsOfUse: React.FC = () => {
+  return (
+    <div id="terms-of-use-page">
+      <Header
+        title="Terms of use"
+        subtitle="Last modified: August 16, 2024"
+        showProgressBar={false}
+      />
+
+      <div className="content-section">
+        <div className="content-section__content">
+          <ContentfulPage pageFields={privacyPolicy} />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/Components/Pages/Results/Results.tsx
+++ b/src/Components/Pages/Results/Results.tsx
@@ -164,10 +164,10 @@ export const Results: React.FC = () => {
             <RentStabilizedProtections />
           )}
           {coverageResult === "UNKNOWN" && (
-              <GoodCauseProtections
-                subtitle="Protections you might have under Good Cause Eviction"
-                rent={Number(fields.rent)}
-              />
+            <GoodCauseProtections
+              subtitle="Protections you might have under Good Cause Eviction"
+              rent={Number(fields.rent)}
+            />
           )}
           {coverageResult === "COVERED" && (
             <>

--- a/src/contentful/ContentfulPage.tsx
+++ b/src/contentful/ContentfulPage.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { PageFields } from "./content-types";
+import { documentToReactComponents } from "@contentful/rich-text-react-renderer";
+import { BLOCKS, INLINES } from "@contentful/rich-text-types";
+import { Asset } from "contentful";
+import { WithJsonifiedDocuments } from "./jsonified-document";
+
+type ContentfulPageProps = {
+  pageFields: WithJsonifiedDocuments<PageFields> | PageFields;
+};
+
+/**
+ * A page defined and localized in Contentful.
+ */
+export const ContentfulPage: React.FC<ContentfulPageProps> = (props) => {
+  const page = props.pageFields as PageFields;
+  const result = documentToReactComponents(page.content, {
+    renderNode: {
+      [BLOCKS.EMBEDDED_ASSET]: (node) => {
+        const asset = node.data.target as Asset;
+        return (
+          <aside className="contentful-asset">
+            <img
+              src={asset.fields.file?.url as string}
+              alt={asset.fields.description as string}
+              className="img-responsive"
+            />
+          </aside>
+        );
+      },
+      [INLINES.HYPERLINK]: (node, children) => (
+        <a href={node.data.uri} target="_blank" rel="noopener noreferrer">
+          {children}
+        </a>
+      ),
+    },
+  });
+
+  return <>{result}</>;
+};

--- a/src/contentful/README.md
+++ b/src/contentful/README.md
@@ -1,0 +1,6 @@
+All of the Contentful code here and the json files in /data are copied from WhoOwnsWhat and only slightly edited to remove lingui localization. In WOW we use contentful but don't connect directly - we have a command to download the pages to static json files like here.
+
+I made only a couple small manual edits to the files here.
+
+- I deleted the first two nodes of each data file for the title and date so that I could manually add those to the header section and preserve our standard page layout.
+- I update the link from terms to privacy to be within GCE and not to WOW.

--- a/src/contentful/content-types.ts
+++ b/src/contentful/content-types.ts
@@ -1,0 +1,21 @@
+import { Document } from "@contentful/rich-text-types";
+
+/**
+ * The name of the Page content type as delivered by the Contentful API.
+ */
+export const PageContentType = "page";
+
+/**
+ * These are the fields for the Page content type, as it's
+ * defined in Contentful.
+ */
+export type PageFields = {
+  /** The title of the page, defined as "short text" in Contentful. */
+  title: string;
+
+  /** The slug of the page, defined as "short text" in Contentful. */
+  slug: string;
+
+  /** The content of the page, defined as "rich text" in Contentful. */
+  content: Document;
+};

--- a/src/contentful/jsonified-document.ts
+++ b/src/contentful/jsonified-document.ts
@@ -1,0 +1,25 @@
+import { Document } from "@contentful/rich-text-types";
+
+/**
+ * This is semantically the same thing as a Contentful `Document` (rich text),
+ * but typed in a way that works with using the `import` statement on a
+ * JSON-serialized Contentful Document. (Annoyingly, the latter doesn't type-match
+ * with a `Document`, so we're hacking the type a bit so clients don't have to
+ * typecast everywhere.)
+ */
+export type JsonifiedDocument = {
+  data: object;
+  content: unknown[];
+  nodeType: string;
+};
+
+/**
+ * Converts all Contentful `Document` fields in the given type to
+ * semantically equivalent fields that properly type-check when using
+ * the `import` statement on a JSON-serialized representation of the
+ * given type. A `WithJsonifiedDocuments<T>` can, for all intents and
+ * purposes, safely be typecast to a `T`.
+ */
+export type WithJsonifiedDocuments<T> = {
+  [K in keyof T]: T[K] extends Document ? JsonifiedDocument : T[K];
+};

--- a/src/data/privacy-policy.en.json
+++ b/src/data/privacy-policy.en.json
@@ -1,0 +1,986 @@
+{
+  "title": "Privacy Policy",
+  "slug": "privacy-policy",
+  "content": {
+    "data": {},
+    "content": [
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [
+              {
+                "type": "underline"
+              }
+            ],
+            "value": "Introduction",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "heading-2"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [],
+            "value": "Welcome! JustFix (“Justfix” or the “Company”)",
+            "nodeType": "text"
+          },
+          {
+            "data": {},
+            "marks": [
+              {
+                "type": "bold"
+              }
+            ],
+            "value": " ",
+            "nodeType": "text"
+          },
+          {
+            "data": {},
+            "marks": [],
+            "value": "is a dedicated 501(c)(3) non-profit organization that seeks to assist tenants in exercising their rights to a livable home. We value the trust you have placed in us and our mission. Justfix is committed to protecting your privacy through our compliance with this privacy policy (the “Policy”) and all relevant laws and regulations that govern the Company.",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "paragraph"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [],
+            "value": "This Policy describes the types of information we may collect from you or that you may provide when you visit the website Justfix.org (our “Website”). This Policy additionally governs any other affiliated products or websites such as Good Cause NYC, WhoOwnsWhat, Letter of Complaint, Los Angeles Tenant Action Center, and any currently existing or future tool created or governed by the Company (collectively, the “Services”).  This Policy describes our practices for collecting, using, maintaining, protecting, and disclosing that information when you visit our Website and/or use our Services. Further, this Policy discloses your rights and ways of contacting the Company to exercise those rights.",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "paragraph"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [],
+            "value": "If you have any questions regarding this Policy please contact support@justfix.org for more information.",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "paragraph"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [
+              {
+                "type": "underline"
+              }
+            ],
+            "value": "Information Collected:",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "heading-2"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [],
+            "value": "By accessing, viewing, visiting, or otherwise interacting with the Website and/or the Services, you agree to the following:",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "paragraph"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "content": [
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "Information may be collected automatically including usage details, IP addresses, and cookies which helps the Company to manage your session with our Website.",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              }
+            ],
+            "nodeType": "list-item"
+          },
+          {
+            "data": {},
+            "content": [
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "You may be prompted to provide your name, email, postal address, zip code, phone number, or other personally identifiable information (“PII”).  By entering this information, you explicitly consent to the Company’s use of your PII, including for use in aggregate information for research purposes of other users on the Website. ",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              }
+            ],
+            "nodeType": "list-item"
+          },
+          {
+            "data": {},
+            "content": [
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "Additional information may be collected such as the features of your browsing and the time spent on a given portion of the Website. We may collect specific information about your device, including the device type, model, mobile carrier, operating system, and preferred language. ",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              }
+            ],
+            "nodeType": "list-item"
+          },
+          {
+            "data": {},
+            "content": [
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "The retention of records or copies of your correspondence if you contact us directly.",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              }
+            ],
+            "nodeType": "list-item"
+          },
+          {
+            "data": {},
+            "content": [
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "We may aggregate, anonymize, and/or de-identify the information described above for purposing of sharing that data with third parties or publishing the aforementioned data. This data would no longer be considered PII due to its anonymization process. This data may be used to assist the Company in improving the Website experience. ",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              }
+            ],
+            "nodeType": "list-item"
+          }
+        ],
+        "nodeType": "unordered-list"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [
+              {
+                "type": "underline"
+              }
+            ],
+            "value": "Use of Your Information:",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "heading-2"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [],
+            "value": "We use information that we collect about you or that you or third-parties provide to us, including any personal information:",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "paragraph"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "content": [
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "To present our Website and Services to you in an ascertainable manner.",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              }
+            ],
+            "nodeType": "list-item"
+          },
+          {
+            "data": {},
+            "content": [
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "To provide you with information, products, or services that you request from us.",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              }
+            ],
+            "nodeType": "list-item"
+          },
+          {
+            "data": {},
+            "content": [
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "To provide you with notices about your account, including lack of use and subsequent deletion of data.",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              }
+            ],
+            "nodeType": "list-item"
+          },
+          {
+            "data": {},
+            "content": [
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "To notify you about changes to our Website and/or Services that the Company provides.",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              }
+            ],
+            "nodeType": "list-item"
+          },
+          {
+            "data": {},
+            "content": [
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "To enable us to display advertisements to our advertisers' target audiences even though we do not disclose your personal information for these purposes.",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              }
+            ],
+            "nodeType": "list-item"
+          },
+          {
+            "data": {},
+            "content": [
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "Any information collected will be retained in accordance with applicable laws. After a period of inactivity, a User may receive an email regarding potential deactivation of a User’s account. The user must affirmatively email the Company in order to ensure retention of their account. Otherwise, their account will be deactivated.",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              }
+            ],
+            "nodeType": "list-item"
+          }
+        ],
+        "nodeType": "unordered-list"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [
+              {
+                "type": "underline"
+              }
+            ],
+            "value": "Disclosure of Your Information",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "heading-2"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [],
+            "value": "We may disclose aggregated information about our users. We may disclose personal information that we collect or you provide as described in this Policy to the following parties:",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "paragraph"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "content": [
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "To our subsidiaries and affiliates.",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              }
+            ],
+            "nodeType": "list-item"
+          },
+          {
+            "data": {},
+            "content": [
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "To contractors, service providers, and other third parties we use to support our business and who are bound by contractual obligations to keep personal information confidential and use it only for the purposes for which we disclose it to them.",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              }
+            ],
+            "nodeType": "list-item"
+          },
+          {
+            "data": {},
+            "content": [
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "To third parties to market their products or services to you. We contractually require these third parties to keep personal information confidential and use it only for the purposes for which we disclose it to them.",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              }
+            ],
+            "nodeType": "list-item"
+          },
+          {
+            "data": {},
+            "content": [
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "To fulfill the purpose for which you provide it.",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              }
+            ],
+            "nodeType": "list-item"
+          },
+          {
+            "data": {},
+            "content": [
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "For any other purpose disclosed by us when you provide the information.",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              }
+            ],
+            "nodeType": "list-item"
+          },
+          {
+            "data": {},
+            "content": [
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "To comply with any court order, law, or legal process, including to respond to any government or regulatory request.",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              }
+            ],
+            "nodeType": "list-item"
+          },
+          {
+            "data": {},
+            "content": [
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "If we believe disclosure is necessary or appropriate to protect the rights, property, or safety of the Company.",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              }
+            ],
+            "nodeType": "list-item"
+          }
+        ],
+        "nodeType": "unordered-list"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [
+              {
+                "type": "underline"
+              }
+            ],
+            "value": "Third-Party Use of Tracking Technologies",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "heading-2"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [],
+            "value": "Some content or applications, including advertisements, on the Website are served by third-parties, including advertisers, content providers, and application providers. These third parties may use cookies, web beacons, or other tracking technologies to collect information about you when you use our website. The information they collect may be associated with your personal information or they may collect information, including personal information, about your online activities across different websites and other online services. They may use this information to provide you with target advertising content.",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "paragraph"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [],
+            "value": "We do not control these third parties' tracking technologies or how they may be used. If you have any questions about an advertisement or other targeted content, you should contact the responsible provider directly. ",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "paragraph"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [
+              {
+                "type": "underline"
+              }
+            ],
+            "value": "Notice and Choice on the Use and Collection of Your Information",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "heading-2"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [],
+            "value": "The Company strives to provide you with choices regarding the personal information you provide to us. We have created mechanisms to provide you with the following control over your information: ",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "paragraph"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "content": [
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [
+                      {
+                        "type": "bold"
+                      }
+                    ],
+                    "value": "Tracking Technologies and Advertising.",
+                    "nodeType": "text"
+                  },
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": " You can set your browser to refuse all or some browser cookies or to alert you when cookies are being sent. If you disable or refuse cookies, please note that some parts of this site may then be inaccessible or not function properly.",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              }
+            ],
+            "nodeType": "list-item"
+          },
+          {
+            "data": {},
+            "content": [
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [
+                      {
+                        "type": "bold"
+                      }
+                    ],
+                    "value": "Disclosure of Your Information for Third-Party Advertising. ",
+                    "nodeType": "text"
+                  },
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "At this time, the Company does not participate in Third-Party advertising. ",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              }
+            ],
+            "nodeType": "list-item"
+          },
+          {
+            "data": {},
+            "content": [
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [
+                      {
+                        "type": "bold"
+                      }
+                    ],
+                    "value": "Targeted Advertising.",
+                    "nodeType": "text"
+                  },
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": " At this time, the Company does not participate in Targeted Advertising. ",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              }
+            ],
+            "nodeType": "list-item"
+          }
+        ],
+        "nodeType": "unordered-list"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [
+              {
+                "type": "underline"
+              }
+            ],
+            "value": "Rights Regarding Your Information",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "heading-2"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [],
+            "value": "You can request some or all of the personal information collected by the Company. You may do this by sending us an email at support@justfix.org. Further, you may contact us at this same email address to request access to, correct, or delete any personal information that you have provided to us. We may not accommodate a request to change information if we believe the change would violate any law or legal requirement or cause the information to be incorrect.",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "paragraph"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [],
+            "value": "For rights specific to residents of certain states please see the section “Specific State Resident Privacy Rights.”",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "paragraph"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [
+              {
+                "type": "underline"
+              }
+            ],
+            "value": "Privacy of Children ",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "heading-2"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [],
+            "value": "The Website and affiliated Services are not intended for users under the age of 13 without parental guidance and active supervision. We do not knowingly collect personal information from users under the age of 13. If you are under the age of 13, do not use or provide any personal information on this Website or affiliated Services.  If you suspect an individual under the age of 13 is accessing our Website or Services please contact us at support@justfix.org. If any information from a user under the age of 13 is collected due to their use of the website and the Company is made aware of such an incident, then any collected information will be promptly deleted. ",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "paragraph"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [
+              {
+                "type": "underline"
+              }
+            ],
+            "value": "Specific State Resident Privacy Rights",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "heading-2"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [],
+            "value": "The California Consumer Privacy Act and California Privacy Rights Acts (“CPRA”), (collectively, as amended, “CCPA”), provide California residents with specific rights in relation to their personal information. To learn more about California resident’s privacy rights, visit ",
+            "nodeType": "text"
+          },
+          {
+            "data": {
+              "uri": "https://oag.ca.gov/privacy/ccpa"
+            },
+            "content": [
+              {
+                "data": {},
+                "marks": [],
+                "value": "https://oag.ca.gov/privacy/ccpa",
+                "nodeType": "text"
+              }
+            ],
+            "nodeType": "hyperlink"
+          },
+          {
+            "data": {},
+            "marks": [],
+            "value": " or contact your local legislature. ",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "paragraph"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [],
+            "value": "In addition to CCPA, California’s “Shine the Light” law (Civil Code Section § 1798.83) permits users of our Website and/or Services who are California residents to request certain information regarding our disclosure of personal information to third parties for their direct marketing purposes. To make such a request, please send an email to support@justfix.org.",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "paragraph"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [
+              {
+                "type": "underline"
+              }
+            ],
+            "value": "Non-US Resident Privacy Rights",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "heading-2"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [],
+            "value": "This Website and its Services are intended for use by citizens, residents, and individuals of the United States. The Website and its Services are not intended for access, use, or distribution outside of the United States and may not protect privacy rights specific to your country of residence. By accessing and/or utilizing this Website or Services you represent and warrant that you are a resident, citizen, or individual of the United States. Any representation to the contrary would be outside of this Policy and the Company’s Terms of Use.",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "paragraph"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [
+              {
+                "type": "underline"
+              }
+            ],
+            "value": "Security of Your Information",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "heading-2"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [],
+            "value": "The retention of information refers to the collection, storage, and management of data. All retained personal information will remain subject to the terms of this Policy.",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "paragraph"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [],
+            "value": "The Company may retain information for the length of time necessary to fulfill the purposes outlined in this Privacy Policy unless a longer retention period is required or permitted by applicable law or regulations. The Company may also retain information to resolve disputes, enforce our legal agreements and policies, and if required to do so by law or regulations that are currently in effect or will become in effect after the publication of this Privacy Policy.  ",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "paragraph"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [],
+            "value": "The Company takes their responsibility to protect the security, integrity, and confidentiality of information very seriously. The Company uses reasonable technical, administrative, and physical security measures to protect information from loss, theft, misuse, unauthorized access, disclosure, modification, and destruction. The Company regularly reviews its security procedures to determine whether the implementation of new technology and methods is feasible and appropriate for safeguarding information.  ",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "paragraph"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [],
+            "value": "Notwithstanding the foregoing, the Company cannot ensure or warrant the security of information. In the event that any information under the Company’s control is compromised as a result of a breach of security, the Company will take reasonable steps to investigate the matter and notify users of the security incident in accordance with applicable laws and regulations.  ",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "paragraph"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [
+              {
+                "type": "underline"
+              }
+            ],
+            "value": "Change of Control",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "heading-2"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [],
+            "value": "In the event that the Company experiences a merger, divestiture, restructuring, reorganization, dissolution, or other sale or transfer of assets, whether as a going concern or as a part of bankruptcy, liquidation, or similar proceeding you consent that your information is among the assets transferred.",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "paragraph"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [
+              {
+                "type": "underline"
+              }
+            ],
+            "value": "Adjustments to our Privacy Policy",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "heading-2"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [],
+            "value": "By accessing, viewing, visiting, or otherwise interacting with the Website and/or the Services, you agree to this Policy. This Policy may change to meet the Company’s needs and certain legal requirements. The continued use of the Website and/or the Services after we make changes is deemed to be acceptance of said change. Please check the policy periodically for updates. The last modified date at the top of this Policy will denote the last update to the Policy.  ",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "paragraph"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [
+              {
+                "type": "underline"
+              }
+            ],
+            "value": "Contact Us",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "heading-2"
+      },
+      {
+        "data": {},
+        "content": [
+          {
+            "data": {},
+            "marks": [],
+            "value": "If you have any questions regarding this Policy please contact ",
+            "nodeType": "text"
+          },
+          {
+            "data": {
+              "uri": "mailto:support@justfix.org"
+            },
+            "content": [
+              {
+                "data": {},
+                "marks": [],
+                "value": "support@justfix.org",
+                "nodeType": "text"
+              }
+            ],
+            "nodeType": "hyperlink"
+          },
+          {
+            "data": {},
+            "marks": [],
+            "value": " for more information.",
+            "nodeType": "text"
+          }
+        ],
+        "nodeType": "paragraph"
+      }
+    ],
+    "nodeType": "document"
+  }
+}

--- a/src/data/terms-of-use.en.json
+++ b/src/data/terms-of-use.en.json
@@ -1,0 +1,2074 @@
+{
+  "title": "Terms of Use",
+  "slug": "terms-of-use",
+  "content": {
+    "nodeType": "document",
+    "data": {},
+    "content": [
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "If you are having any trouble accessing our website or these Terms, please email us at support@justfix.org to receive these Terms in an alternate format.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "Welcome to JustFix!",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "JustFix, Inc. (collectively, “JustFix,” “we,” “our,” or “us”) own and operate this website, ",
+            "marks": [],
+            "data": {}
+          },
+          {
+            "nodeType": "hyperlink",
+            "data": {
+              "uri": "https://justfix.org"
+            },
+            "content": [
+              {
+                "nodeType": "text",
+                "value": "https://justfix.org",
+                "marks": [
+                  {
+                    "type": "underline"
+                  }
+                ],
+                "data": {}
+              }
+            ]
+          },
+          {
+            "nodeType": "text",
+            "value": " (the “Site”). These terms of use (the “Agreement”) constitute a contract between you and us. This means that by accessing and/or using the Site, you agree to all of the terms and conditions of this Agreement. These terms and conditions also govern your use of all features, widgets, plug-ins, applications, content, downloads, and/or other services that we own and control and make available through the Site (collectively, with the Site, the “Service”), regardless of how you access or use it, whether via computer, mobile device, or otherwise. By using this Service, you are deemed to have agreed to these Terms and Conditions of Use. JustFix may change the Terms and Conditions of Use from time to time and at any time, and without actual notice to you. Any such modification will be effective immediately upon public notice and posting. If at any time you choose not to accept these Terms and Conditions of Use, please do not use this Site. Your continued use of our Service and this Site following any such modifications constitutes your acceptance of these modified Terms. The following Terms of Service are a legal contract between you (“you” and “your”) and JustFix regarding your use of the Services. Visitors and users of the Services are referred to individually as “user” and collectively as “users.” Use of the Services is governed by the Terms of Use and our Privacy Policy, where the Privacy Policy describes the personal information that we collect and how we protect and use it.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "PLEASE READ THE FOLLOWING TERMS OF USE CAREFULLY. BY ACCESSING, BROWSING, OR USING THE WEBSITE, YOU ACKNOWLEDGE THAT YOU HAVE READ, UNDERSTOOD, AND AGREE TO BE BOUND BY THE FOLLOWING TERMS AND CONDITIONS, AND ANY ADDITIONAL GUIDELINES (AS DEFINED BELOW) (COLLECTIVELY, THE “TERMS”), AND THAT YOU HAVE READ THE JUSTFIX ",
+            "marks": [],
+            "data": {}
+          },
+          {
+            "nodeType": "hyperlink",
+            "data": {
+              "uri": "/privacy_policy"
+            },
+            "content": [
+              {
+                "nodeType": "text",
+                "value": "PRIVACY POLICY",
+                "marks": [
+                  {
+                    "type": "underline"
+                  }
+                ],
+                "data": {}
+              }
+            ]
+          },
+          {
+            "nodeType": "text",
+            "value": ".",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "PLEASE NOTE THAT THESE TERMS INCLUDE A BINDING ARBITRATION PROVISION INCLUDING A CLASS ACTION WAIVER. BY AGREEING TO BINDING ARBITRATION, TO THE EXTENT PERMITTED UNDER APPLICABLE LAW, YOU WAIVE YOUR RIGHT TO LITIGATE DISPUTES THROUGH A COURT AND TO HAVE A JUDGE OR JURY DECIDE YOUR CASE.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-1",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "1. Eligibility; Accounts",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "THE WEBSITE IS NOT AVAILABLE TO ANY PERSONS UNDER THE AGE OF 13 WHOSE REGISTRATION HAS NOT BEEN APPROVED BY A LEGAL PARENT OR GUARDIAN.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "1.1. Acceptance",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "By clicking the “I agree” button or by otherwise using the JustFix website for the Services, you present that (i) you are at least 13 years of age, or (ii) your use of the Services has been approved by your parent or legal guardian. You also represent that you have not been previously suspended or removed from the Services by JustFix, and that your use of the Services is in compliance with any and all applicable laws.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "1.2. Account",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "You agree that the information you provide to JustFix, whether at registration or at any other time, will be true, accurate, current, and complete. You may be asked to create an account or complete a user registration. In the event you are asked to create an account, you also agree that you will ensure this information is kept accurate and updated at all times. If you have reason to believe that your account is no longer secure, such as loss, theft, or unauthorized disclosure of your username or password, then you agree to immediately notify JustFix at support@justfix.org. You may be liable for the losses incurred by JustFix or others due to any unauthorized use of your Services account.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "1.3. Age",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "JustFix is offered and available to users of all ages. By using the Website, you represent and warrant that you are either of legal age to form a binding contract with JustFix, or if you are under the age of 18, that you have appropriate parental or legal guardian consent, permission, or supervision. For children 13 years old and under, a parent or legal guardian must provide JustFix with verifiable consent. Please see our Privacy Policy for a more detailed explanation of what information we collect, how we use that information, specific privacy practices for children under 13 years old, and how to provide us with verifiable parental consent.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "1.4. Permission by Parent or Guardian",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "If you are at least 18 years of age, you represent and warrant that you have your parent or legal guardian’s permission to use the Service. Please have them read these Terms with you.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "If you are a parent or legal guardian of a member under 18 years of age, by allowing your child to use the Service, you are subject to these Terms and are responsible for your child’s activity on the Service.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "1.5. Businesses",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "If you are using the Services in connection with a company or organization, you represent and warrant that you have the authority to act on",
+            "marks": [],
+            "data": {}
+          },
+          {
+            "nodeType": "text",
+            "value": " ",
+            "marks": [
+              {
+                "type": "bold"
+              }
+            ],
+            "data": {}
+          },
+          {
+            "nodeType": "text",
+            "value": "behalf of that entity, and that such entity agrees to these Terms.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "1.6. International Use.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "JustFix operates only within the United States and is intended for users located within the United States. JustFix does not offer services to those outside of the United States, even if the user views JustFix’s websites from a location outside of the United States. ",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-1",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "2. Privacy Policy",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "JustFix is conscious of privacy issues and want all users, parents, students, and School Personnel alike to be familiar with our data practices. Please read the ",
+            "marks": [],
+            "data": {}
+          },
+          {
+            "nodeType": "hyperlink",
+            "data": {
+              "uri": "/privacy_policy"
+            },
+            "content": [
+              {
+                "nodeType": "text",
+                "value": "JustFix Privacy Policy",
+                "marks": [
+                  {
+                    "type": "underline"
+                  }
+                ],
+                "data": {}
+              }
+            ]
+          },
+          {
+            "nodeType": "text",
+            "value": " carefully for information regarding JustFix’s collection, use, and disclosure of your personally identifiable information. JustFix’s privacy policy explains how we store and protect your personally identifiable information. We also explain how to view, access, correct, or delete your personal information. To inquire about your privacy with JustFix, please email us at ",
+            "marks": [],
+            "data": {}
+          },
+          {
+            "nodeType": "hyperlink",
+            "data": {
+              "uri": "mailto:support@justfix.org"
+            },
+            "content": [
+              {
+                "nodeType": "text",
+                "value": "support@justfix.org",
+                "marks": [
+                  {
+                    "type": "underline"
+                  }
+                ],
+                "data": {}
+              }
+            ]
+          },
+          {
+            "nodeType": "text",
+            "value": ".",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-1",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "3. Other Guidelines",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "When using the Services, you will be subject to any additional posted guidelines or rules applicable to specific services and features which may be posted from time to time (the “Guidelines”). All such Guidelines are hereby incorporated by reference into the Terms.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-1",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "4. Modification of the Terms",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "4.1. General",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "We may change this Agreement from time to time and without prior notice. If we make a change to this Agreement, it will be effective as soon as we post it, and the most current version of this Agreement will always be posted under the “Terms of Use” tab (“Updated Terms”). If we make a material change to the Agreement, we may notify you. You agree that you will review this Agreement periodically and that you shall be bound by any updates or modifications to the Agreement. By continuing to access and/or use the Site after we post Updated Terms, you agree to be bound by the Updated Terms, and if you do not agree to the Updated Terms, you will stop using the Site. This Agreement between you and JustFix will govern any disputes arising before the effective date of the Updated Terms.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-1",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "5. Digital Millennium Copyright Act",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "It is JustFix’s policy to respond to notices of alleged copyright infringement that comply with the Digital Millennium Copyright Act. JustFix will promptly terminate without notice your access to the Services if JustFix determines you to be a “repeat infringer.” A repeat infringer is a User who has been notified by JustFix of infringing activity violations more than twice and/or who has User Content or any other user-submitted content removed from the Services more than twice.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-1",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "6. Proprietary Materials; Licenses",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "6.1. Proprietary Materials",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "The Services are owned and operated by JustFix. The materials and other items relating to JustFix and its products and services, and similar items from our licensors and other third parties, including all visual interfaces, layout, information, posts, text, data, files, images, scripts, graphics, designs, button icons, instructions, illustrations, photographs, pictures, advertising copy, URLs, technology, information, computer code (including source code or object code), software, services, interactive features, the “look and feel” of the Service, content, articles, videos, and exercises, and all other elements of the Services (the “Service Materials”), and the compilation, assembly, and arrangement of the Service Materials are protected by United States and international copyright, patent, trademark, trade secret, international conventions, and other applicable laws governing intellectual property and proprietary rights to the fullest extent possible. All Service Materials, and all trademarks, logos, service marks, and trade names, trade dress, and trade identities of various parties contained on or available through the Services are owned by or controlled by JustFix, and JustFix reserves all rights therein and thereto not expressly granted by these Terms. ",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "6.2. Non-Commercial Use",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "Without limiting the foregoing, JustFix grants you a limited, non-exclusive, revocable, non-assignable, personal, and non-transferable license to download and copy (temporary storage only of web site content), display, view, use, play the Content on a personal computer, browser, laptop, tablet, mobile phone or other wireless device, or other Internet-enabled device (each, a “Device”), and/or print one copy of the Content (excluding source and object code in raw form or otherwise) as it is displayed to you, in each case for your personal, non-commercial use only. The foregoing limited license (i) does not give you any ownership of, or any other intellectual property interest in, any Content, and (ii) may be immediately suspended or terminated for any reason, in JustFix’s sole discretion, and without advance notice or liability. In some instances, we may permit you to have greater access to and use of Content subject to certain Additional Terms. Your breach of any of these Terms or Additional Terms automatically terminates this license. The Licensed Content may not be used, distributed, or otherwise exploited for any commercial purpose, commercial advantage, or private monetary compensation, unless otherwise previously agreed in writing by JustFix.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-3",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "6.2.1. Impermissible Uses.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "Without limiting the generality of the foregoing, JustFix expressly defines the following as falling outside of non-commercial use:",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-5",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "6.2.1.1. The sale or rental of (i) any part of the Licensed Content, (ii) any derivative work based at least in part on the Licensed Content, or (iii) any collective work that includes any part of the Licensed Content;",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-5",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "6.2.1.2. Providing training, support, or editorial services that use or reference the Licensed Content in exchange for a fee; and",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-5",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "6.2.1.3. The sale of advertisements, sponsorships, or promotions placed on the Licensed Content, or any part thereof, or the sale of advertisements, sponsorships, or promotions on any website or blog containing any part of the Licensed Content, including without limitation any “pop-up advertisements.”",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-3",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "6.2.2. Links By You To The Service",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "We grant you a limited, non-exclusive, revocable, non-assignable, personal, and non-transferable license to create hyperlinks to the Service, so long as: (a) the links only incorporate text, and do not use any Trademarks, (b) the links and the content on your website do not suggest any affiliation with JustFix or cause any other confusion, and (c) the links and the content on your website do not portray JustFix or its products or services in a false, misleading, derogatory, or otherwise offensive matter, and do not contain content that is unlawful, offensive, obscene, lewd, lascivious, filthy, violent, threatening, harassing, or abusive, or that violate any right of any third party or are otherwise objectionable to JustFix. JustFix reserves the right to suspend or prohibit linking to the Service for any reason, in its sole discretion, without advance notice or any liability of any kind to you or any third party.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-1",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "7. Prohibited Conduct",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "YOU AGREE NOT TO:",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-5",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "7.1. Access the Services without proper authorization;",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-5",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "7.2. Use the Services for any commercial use or purpose unless expressly permitted by JustFix in writing, it being understood that the Services and related services are intended for personal, non-commercial use only;",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-5",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "7.3. Except as expressly permitted under Section 7 of these Terms, rent, lease, loan, sell, resell, sublicense, distribute, or otherwise transfer the licenses for any Service Materials;",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-5",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "7.4. Distribute any content that is unlawful or that a reasonable person could deem to be objectionable, offensive, indecent, pornographic, harassing, threatening, embarrassing, distressing, vulgar, hateful, racially or ethnically offensive, promoting of violence, hostility, or discrimination, or otherwise inappropriate;",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-5",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "7.5. Use the Services in any manner that is harmful to minors;",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-5",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "7.6. Impersonate any person or entity, falsely claim an affiliation with any person or entity, or access the accounts of others without permission, create accounts via bots or other automated means, or perform any other fraudulent activity;",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-5",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "7.7. Develop, support, or use software, devices, scripts, robots, or any other means or processes (including crawlers, browser plugins and add-ons, or any other technology) to scrape the Services, or otherwise copy our content and other data from the Services;",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-5",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "7.8. Use bots or other automated methods to access the Services;",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-5",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "7.9 Frame or utilize framing techniques to enclose any such Content (including any images, text, or page layout);",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-5",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "7.10. Delta (or otherwise obscure or alter) the copyright or other proprietary rights notices on the Services or on any Licensed Content;",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-5",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "7.11. Assert, or authorize, assist, or encourage any third party to assert, against JustFix or any of its affiliates or licensors any patent infringement or other intellectual property infringement claim regarding any Licensed Content you have used, submitted, or otherwise made available on or through the Services;",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-5",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "7.12. Copy, modify, reproduce, archive, sell, lease, rent, exchange, create derivative works from, publish by hard copy or electronic means, publicly perform, display, disseminate, distribute, broadcast, retransmit, circulate, or transfer to any third party or on any third-party application or website, or otherwise use or exploit such Content in any way for any purpose except as specifically permitted by these Terms or any applicable Additional Terms or with the prior written consent of an officer of JustFix or, in the case of Content from a licensor, the owner of the Content.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-5",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "7.13. Make unsolicited offers, advertisements, proposals, or send junk mail or spam to other Users of the Services (including, but not limited to, unsolicited advertising, promotional materials, or other solicitation material, bulk mailing of commercial advertising, chain mail, informational announcements, charity requests, and petitions for signatures);",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-5",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "7.14. Use the Services for any illegal purpose, or in violation of any local, state, national, or international law, including, without limitation, laws governing intellectual property and other proprietary rights, and data protection and privacy;",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-5",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "7.15. Defame, harass, bully, abuse, threaten, or defraud Users of the Services, or collect, or attempt to collect, personal information about Users or third parties without their consent;",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-5",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "7.16. Probe, scan, remove, circumvent, disable, damage, or otherwise interfere with or test the vulnerability of security-related features of the Services, Licensed Content, features that prevent or restrict use or copying of any content accessible through the Services, or features that enforce limitations on the use of the Services, Licensed Content, or otherwise access, tamper with, or use non-public portions of the Services our authorization;",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-5",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "7.17. Reverse engineer, decompile, disassemble, or otherwise attempt to discover the source code of the Services or any part thereof, except and only to the extent that such activity is expressly permitted by applicable law (in which case you must contact JustFix to give notice of the proposed activity and discuss alternative means to obtain the desired information from JustFix) notwithstanding this limitation;",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-5",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "7.18. Modify, adapt, translate, or create derivative works based upon the Services or any part thereof, except and only to the extent expressly permitted by JustFix herein or to the extent the foregoing restriction is expressly prohibited by applicable law (in which case you must contact JustFix to give notice of the proposed activity and discuss whether JustFix is willing to provide the desired derivative works); or",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-5",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "7.19. Intentionally interfere with or damage operation of the Services or any user’s enjoyment of it, by any means, including without limitation by participation in any denial-of-service type attacks or by uploading or otherwise disseminating viruses, adware, spyware, worms, or other malicious code.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-1",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "8. Third-Party Content and Sites, Products and Services; Advertisements; Links",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "8.1. Third-Party Content and Sites; Advertisements",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "The Service may contain or may interact with or otherwise be associated with third party platforms, services, plug-ins, applications, ads, tools, and/or other content, and/or links to third-party websites or other services that are not owned, controlled, or operated by JustFix (collectively, “Third-Party Services”), including services operated by advertisers, licensors, licensees, e-commerce partners, and certain other third parties who may have business relationships with JustFix. We may also host our content, apps, and tools on Third-Party Services. JustFix may have no control over the content, operations, policies, terms, or other elements of Third-Party Services, and JustFix does not assume any obligation to review any Third-Party Services. JustFix does not necessarily endorse, approve, or sponsor any Third-Party Services, or any third-party content, advertising, information, materials, products, services, or other items. Furthermore, JustFix is not responsible for the quality or delivery of the products or services offered, accessed, obtained by, or advertised at, such Third-Party Services. Some Third-Party Services may impose fees for access to their resources through our Service and you are responsible for all such fees. Finally, as permitted by applicable law, we will under no circumstances be liable for any direct, indirect, incidental, or special loss or other damage, whether arising from negligence, breach of contract, defamation, infringement of copyright or other intellectual property rights, caused by the exhibition, distribution, or exploitation of any information or content contained within these Third-Party Services. Any activities you engage in connection with any of the same are subject to the privacy and other policies, terms, and conditions of use and/or sale, and rules issued by the operator of the Third-Party Services. JustFix disclaims all liability in connection therewith, as permitted by applicable law. ACCESS AND USE OF REFERENCE SITES, INCLUDING THE INFORMATION, MATERIALS, PRODUCTS, AND SERVICES ON OR AVAILABLE THROUGH REFERENCE SITES, IS SOLELY AT YOUR OWN RISK.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "8.2. Dealings with Third Parties",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "Any interactions, correspondence, transactions, and other dealings that you have with any third parties found on or through the Service (including on or via Third Party-Services or advertisements) are solely between you and the third party (including issues related to the content of third-party advertisements, payments, delivery of goods, warranties (including product warranties), privacy and data security, and the like). For more information about the implications of activating these Third Party-Services and our use, storage, and disclosure of information related to you and your use of such services within our Service, please see our Privacy Policy. As permitted by applicable law, you hereby agree to indemnify JustFix against all claims, injury, and/or damages including, without limitation, attorneys’ fees, that arise out of your use of any Third Party-Service, including without limitation from any material that you post on any forum or social networking site in connection with us and/or any other claim related to your use of social media.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "As permitted by applicable law, you hereby grant JustFix an irrevocable perpetual license to use, reproduce, edit, create derivative works from, distribute, display, copy, transmit, or otherwise use in any way, commercially or otherwise, any material that you may post to any social networking site or other Third-Party Service in connection with us or our Service.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-1",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "9. Messages",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "9.1. Text Messages",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "You may be given opportunities to subscribe to various text marketing or other text messaging programs and by doing so, you consent to receive ongoing text alerts (including by auto-dialers) from us related to our various businesses and affiliates, which may include co-promotions with or about other parties, except that if the scope of your consent for a particular subscription is limited that subscription will be so limited. Such consent is not required for any service aside from the text subscription itself. For each subscription, you will have the option to opt-out. Subsequent or different subscriptions will be unaffected by an opt-out. You consent to receive a text confirming any opt-out as well as non-marketing administrative or transactional messages. For subscriptions to recurring text messages, you may receive up to the number of text messages per month specified in your consent, or to which you later consent. Alerts auto-renew unless otherwise specified when you consented. You understand that we will send mobile text messages using automated technology. If you subscribe to text messages, you represent that you are 18 years of age or older or have obtained parental consent. Standard message, data, and other fees may be charged by your carrier, and carriers may deduct charges from pre-paid amounts or data allowances, for which you are responsible. Contact your carrier for details. If we are charging a premium rate for text messages, that will be explained in the applicable subscription consent. Not all phones and/or carriers are supported. We are the sponsor of our text messages and may be contacted regarding them at: support@justfix.org.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "9.2. Email Messages",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "You may cancel or modify our email marketing communications you may receive from us by following the instructions contained within our promotional emails. This will not affect subsequent subscriptions and if your opt-out is limited to certain types of emails, then the opt-out will be so limited. Please note that we reserve the right to send you certain communications relating to your use of our Service, such as administrative and service announcements and these transactional messages may be unaffected if you choose to opt-out from receiving our marketing communications.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "9.3. Email Alerts",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "To access the Email Alerts feature of JustFix, users are required to provide a valid email address and create a password. Users will also be asked to select an option that best describes their use case of the product, including, but not limited to tenant, tenant organizer, or housing attorney. This information is collected to tailor the Email Alerts to the user’s specific interests and needs. JustFix will associate users’ use case selections with their email addresses for the purpose of delivering more relevant content. Users will have the ability to manage their accounts via the JustFix website. This includes updating their email address, changing their password, and managing their preferences for receiving data about specific building addresses. JustFix will not delete user accounts. However, if analytics indicate that a user has not engaged with our emails over a certain period, JustFix reserves the right to unsubscribe the user from the Email Alerts service. Users may receive a notification email and receive adequate time to consider inactivity before being automatically unsubscribed. The delivery of Email Alerts will be facilitated through SendGrid, a third-party email delivery service. Additionally, JustFix utilizes Email on Acid for email analytics and testing support. Users’ email interactions, including link clicks, will be monitored using Google Analytics embedded in the emails for the purpose of improving the Email Alerts service. JustFix uses a “no-reply” email address and may implement an automated reply. Direct user feedback or inquiries should be directed through the specified channels on the JustFix website. Users have the right to unsubscribe from the Email Alerts service at any time through their account settings or by following the unsubscribe instructions in the email. Additionally, JustFix reserves the right to manually unsubscribe users from the service at its discretion.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-1",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "10. Term ",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "10.1. Term and Termination",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "These Terms shall remain in full force and effect while you use the Sites or the Services and thereafter.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "Without limiting any other provision of these Terms, we reserve the right to, in our sole discretion and without notice or liability, deny access to and use of the Sites and the Services (including blocking certain IP addresses), to any person for any reason or for no reason, including without limitation for breach of any representation, warranty, or covenant contained in these Terms or of any applicable law or regulation. We may terminate your use or participation in the Sites or other Services, or delete your account and any Content or information that you posted at any time, without warning, in our sole discretion.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "If we terminate or suspend your account for any reason, you are prohibited from registering and creating a new account under your name, a fake or borrowed name, or the name of any third party, even if you may be acting on behalf of the third party. In addition to terminating or suspending your account, we reserve the right to take appropriate legal action, including without limitation pursuing civil, criminal, and injunctive redress. This Section 10 is not subject to dispute resolution terms of Section 14.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "10.2. Representations and Warranties",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "You warrant, represent, and agree that you will not use the Services in a manner that (i) infringes, violates, or misappropriates another’s intellectual property rights, rights of publicity or privacy or other rights; (ii) violates any international, federal, state, or local law, statute, ordinance, or regulation which would render JustFix in violation of any applicable laws or regulations, including without limitation, Applicable Privacy Laws (“Applicable Laws”); (iii) is harmful, fraudulent, threatening, abusive, harassing, tortuous, defamatory, vulgar, obscene, libelous, or otherwise objectionable; or (iv) jeopardizes the security of your account or the Services in any way, such as allowing someone else access to your account or password. Additionally, you represent, warrant, and agree that (i) you will possess all rights necessary to grant Company rights in these Terms, and (ii) you will comply with Applicable Laws in connection with your use of the Service.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-3",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "10.2.1. Disclaimer of Representations and Warranties",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "As permitted by applicable Law, the service is provided on an “as is,” “as available,” and “with all faults” basis and your access to and use of the Service is at your sole risk. Therefore, to the fullest extent permissible by applicable law, JustFix and its direct and indirect parents, subsidiaries, affiliates, and each of their respective employees, directors, members, managers, shareholders, agents, vendors, licensors, licensees, contractors, customers, successors, and assigns (collectively, “JustFix Parties”) hereby disclaim and make no representations, warranties, endorsements, or promises, express or implied, in connection with, or otherwise directly or indirectly related to, the Service (including the Content), including without limitation:",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "unordered-list",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "list-item",
+            "data": {},
+            "content": [
+              {
+                "nodeType": "paragraph",
+                "data": {},
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "(a) the functions, features, or any other elements on, or made accessible through, the Service;",
+                    "marks": [],
+                    "data": {}
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "nodeType": "list-item",
+            "data": {},
+            "content": [
+              {
+                "nodeType": "paragraph",
+                "data": {},
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "(b) any Content, products, services, or instructions offered, referenced, or linked through the Service;",
+                    "marks": [],
+                    "data": {}
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "nodeType": "list-item",
+            "data": {},
+            "content": [
+              {
+                "nodeType": "paragraph",
+                "data": {},
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "(c) security associated with your use of the Service;",
+                    "marks": [],
+                    "data": {}
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "nodeType": "list-item",
+            "data": {},
+            "content": [
+              {
+                "nodeType": "paragraph",
+                "data": {},
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "(d) whether the Service or the servers that make the Service available are free from any harmful components (including viruses, Trojan horses, and other technologies that could adversely impact your Device);",
+                    "marks": [],
+                    "data": {}
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "nodeType": "list-item",
+            "data": {},
+            "content": [
+              {
+                "nodeType": "paragraph",
+                "data": {},
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "(e) whether the information (including any instructions) on the Service is accurate, complete, correct, adequate, useful, timely, or reliable;",
+                    "marks": [],
+                    "data": {}
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "nodeType": "list-item",
+            "data": {},
+            "content": [
+              {
+                "nodeType": "paragraph",
+                "data": {},
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "(f) whether any defects to or errors on the Service will be repaired or corrected;",
+                    "marks": [],
+                    "data": {}
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "nodeType": "list-item",
+            "data": {},
+            "content": [
+              {
+                "nodeType": "paragraph",
+                "data": {},
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "(g) whether the Service will be compatible with any other specific hardware, software, or service;",
+                    "marks": [],
+                    "data": {}
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "nodeType": "list-item",
+            "data": {},
+            "content": [
+              {
+                "nodeType": "paragraph",
+                "data": {},
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "(h) whether your access to the Service will be uninterrupted; ",
+                    "marks": [],
+                    "data": {}
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "nodeType": "list-item",
+            "data": {},
+            "content": [
+              {
+                "nodeType": "paragraph",
+                "data": {},
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "(i) whether the Service will be available at any particular time or location; and",
+                    "marks": [],
+                    "data": {}
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "nodeType": "list-item",
+            "data": {},
+            "content": [
+              {
+                "nodeType": "paragraph",
+                "data": {},
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "(j) whether your use of the Service is lawful in any particular jurisdiction. ",
+                    "marks": [],
+                    "data": {}
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "Except for any specific warranties provided herein or in additional terms provided by a JustFix party, as permitted by applicable law, JustFix parties hereby further disclaim all warranties, express or implied, including the warranties of merchantability, fitness for a particular purpose, non-infringement or misappropriation of intellectual property rights of third parties, title, custom, trade, quiet enjoyment, system integration, and freedom from computer virus.",
+            "marks": [
+              {
+                "type": "bold"
+              }
+            ],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "The warranty limitations in this Section are not intended to limit any express warranties from applicable product manufacturers of physical products sold via the Service, or any express warranties by JustFix that are included in applicable Additional Terms, or your remedies required under applicable law to be available to you for personal injury claims arising out of product liability, or which are otherwise not waivable under applicable law.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-1",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "11. Indemnification",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "You agree, to the extent permissible under your state’s laws, to indemnify, defend, and hold harmless JustFix, and its parent, successors, affiliated companies, contractors, officers, directors, employees, agents, and its third-party suppliers, licensors, and partners (“JustFix’s Partners”) from and against all losses, damages, liabilities, demands, judgments, settlements, costs, and expenses of any kind (including legal fees and expenses), from any claim or demand made by any third-party relating to or arising out of (i) your access to, use or misuse of the Services; (ii) your breach or alleged breach of these Terms, or any violation of the Terms; (iii) any breach of the representations, warranties, and covenants made herein; (iv) your failure to comply with Applicable Laws (including any failure to obtain or provide any necessary consent or notice); (v) the infringement by you or any third-party using your account of any intellectual property, privacy, or other right of any person or entity; or (vi) your breach or alleged breach of any interaction, agreement, or policy between you and any other Users. JustFix reserves the right, at your expense, to assume the exclusive defense and control of any matter for which you are required to indemnify JustFix, and you agree to cooperate with JustFix’s defense of these claims. You agree not to settle any such matter without the prior written consent of JustFix. JustFix will use reasonable efforts to notify you of any such claim, action, or proceeding upon becoming aware of it.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-1",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "12. Disclaimers; No Warranties",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "12.1. No Warranties",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "THE WEBSITE, AND ALL DATA, INFORMATION, SOFTWARE, WEBSITE MATERIALS, CONTENT (WHETHER OWNED OR LICENSED), USER CONTENT, REFERENCE SITES, SERVICES, OR APPLICATIONS MADE AVAILABLE IN CONJUNCTION WITH OR THROUGH THE WEBSITE (THE “JUSTFIX OFFERINGS”), ARE PROVIDED ON AN “AS IS,” “AS AVAILABLE,” AND “WITH ALL FAULTS” BASIS. TO THE FULLEST EXTENT PERMISSIBLE PURSUANT TO APPLICABLE LAW, JUSTFIX DISCLAIMS ANY AND ALL WARRANTIES AND CONDITIONS OF ANY KIND, WHETHER STATUTORY, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, ALL IMPLIED WARRANTIES OF MERCHANTABILITY, QUALITY, AVAILABILITY, QUIET ENJOYMENT, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT. NO ADVICE OR INFORMATION, WHETHER ORAL OR WRITTEN, OBTAINED BY YOU FROM JUSTFIX OR THROUGH THE WEBSITE WILL CREATE ANY WARRANTY NOT EXPRESSLY STATED HEREIN.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "12.2. Content",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "JUSTFIX DOES NOT WARRANT THAT THE WEBSITE OR ANY DATA, USER CONTENT, FUNCTIONS, OR ANY OTHER INFORMATION OFFERED ON OR THROUGH THE WEBSITE WILL BE UNINTERRUPTED, OR FREE OF ERRORS, VIRUSES, OR OTHER HARMFUL COMPONENTS, AND DO NOT WARRANT THAT ANY OF THE FOREGOING WILL BE CORRECTED. SOME FEATURES MAY BE NEW OR EXPERIMENTAL AND MAY NOT HAVE BEEN TESTED IN ANY MANNER.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "JUSTFIX MAKES NO REPRESENTATION OR WARRANTY THAT (1) JUSTFIX OFFERINGS WILL (A) MEET YOUR REQUIREMENTS OR EXPECTATIONS, OR (B) BE TO YOUR LIKING.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "12.3. Harm to your Computer",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "YOU UNDERSTAND AND AGREE THAT YOUR USE, ACCESS, DOWNLOAD, OR OTHERWISE OBTAINING OF CONTENT, WEBSITE MATERIALS, SOFTWARE, OR DATA THROUGH THE WEBSITE (INCLUDING THROUGH ANY APPLICATION PROGRAMMING INTERFACE (APIs)) IS AT YOUR OWN DISCRETION AND RISK, AND THAT YOU WILL BE SOLELY RESPONSIBLE FOR ANY DAMAGE TO YOUR PROPERTY (INCLUDING YOUR COMPUTER SYSTEM) OR LOSS OF DATA THAT RESULTS THEREFROM.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "12.4. Limitation by Applicable Law",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "SOME STATES OR OTHER JURISDICTIONS DO NOT ALLOW THE EXCLUSION OF IMPLIED WARRANTIES, SO THE ABOVE EXCLUSIONS MAY NOT APPLY TO YOU. YOU MAY ALSO HAVE OTHER RIGHTS THAT VARY FROM STATE TO STATE AND JURISDICTION TO JURISDICTION.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-1",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "13. Limitation of Liability and Damages",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "13.1. Limitation of Liability",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "UNDER NO CIRCUMSTANCES, INCLUDING, BUT NOT LIMITED TO, NEGLIGENCE, WILL JUSTFIX BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL, CONSEQUENTIAL, PUNITIVE, RELIANCE, OR EXEMPLARY DAMAGES (INCLUDING WITHOUT LIMITATION DAMAGES ARISING FROM ANY UNSUCCESSFUL COURT ACTION OR LEGAL DISPUTE, LOST BUSINESS, LOST REVENUES OR PROFITS, LOSS OF DATA, OR ANY OTHER PECUNIARY OR NON-PECUNIARY LOSS OR DAMAGE OF ANY NATURE WHATSOEVER) EVEN IF JUSTFIX HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES ARISING OUT OF OR RELATING TO (i) THE TERMS; (ii) YOUR USE OF (OR INABILITY TO USE) THE WEBSITE OR THE JUSTFIX OFFERINGS; OR (iii) ANY OTHER INTERACTIONS WITH JUSTFIX INCLUDING OTHER USERS. APPLICABLE LAW MAY NOT ALLOW THE LIMITATION OR EXCLUSION OF LIABILITY OR INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THE ABOVE LIMITATION OR EXCLUSION MAY NOT APPLY TO YOU. IN SUCH CASES, JUSTFIX’S LIABILITY WILL BE LIMITED TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "13.2. Limitation of Damages",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "IN NO EVENT WILL JUSTFIX’S TOTAL LIABILITY TO YOU FOR ALL DAMAGES, LOSSES, AND CAUSES OF ACTION ARISING OUT OF OR RELATING TO THE TERMS OR YOUR USE OF THE WEBSITE OR YOUR INTERACTION WITH OTHER WEBSITE USERS (WHETHER IN CONTRACT, TORT (INCLUDING NEGLIGENCE), WARRANTY OR OTHERWISE), EXCEED THE AMOUNT PAID BY YOU TO JUSTFIX, IF ANY, FOR ACCESSING THE WEBSITE DURING THE TWELVE (12) MONTHS IMMEDIATELY PRECEDING THE DATE OF THE CLAIM OR ($100), WHICHEVER IS GREATER.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "13.3. Basis of the Bargain",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "YOU ACKNOWLEDGE AND AGREE THAT JUSTFIX HAS OFFERED THE WEBSITE AND ENTERED INTO THE TERMS IN RELIANCE UPON THE DISCLAIMERS AND THE LIMITATIONS OF LIABILITY SET FORTH HEREIN, THAT THE DISCLAIMERS AND THE LIMITATIONS OF LIABILITY SET FORTH HEREIN REFLECT A REASONABLE AND FAIR ALLOCATION OF RISK BETWEEN YOU AND JUSTFIX, AND THAT THE DISCLAIMERS AND THE LIMITATIONS OF LIABILITY SET FORTH HEREIN FORM AN ESSENTIAL BASIS OF THE BARGAIN BETWEEN YOU AND JUSTFIX. JUSTFIX WOULD NOT BE ABLE TO PROVIDE THE WEBSITE TO YOU ON AN ECONOMICALLY REASONABLE BASIS WITHOUT THESE LIMITATIONS.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-1",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "14. Miscellaneous (including dispute resolution and arbitration)",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "14.1. Notice",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "JustFix may provide you with notices, including those regarding changes to the Terms, by email, regular mail, postings on the Services, or other reasonable means. Notices will be deemed given twenty-four (24) hours after email is sent, unless JustFix is notified that the email address is invalid. Alternatively, we may give you legal notice by mail to a postal address, if provided by you through the Services. In such cases, notice will be deemed given three days after the date of mailing. Notices posted on the Services are deemed given 30 days following the initial posting. Any notices directed to JustFix shall be sent by first class U.S. Mail to JustFix at ",
+            "marks": [],
+            "data": {}
+          },
+          {
+            "nodeType": "text",
+            "value": "137 Montague Street, PMB #211, Brooklyn NY 11201 ",
+            "marks": [],
+            "data": {}
+          },
+          {
+            "nodeType": "text",
+            "value": "with a copy sent to support@justfix.org.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "14.2. Waiver",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "The failure of JustFix to exercise or enforce any right or provision of the Term will not constitute a waiver of such right or provision. Any waiver of any provision to the Terms will be effective only if in writing and signed by JustFix.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "14.3. Governing Law",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "The Terms will be governed by and construed in accordance with the laws of the State of New York, without giving effect to any principles of conflicts of law that would cause the application of the laws of any other jurisdiction.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "14.4. Dispute Resolution and Arbitration",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "PLEASE READ THIS SECTION CAREFULLY BECAUSE IT AFFECTS YOUR RIGHTS. BY AGREEING TO BINDING ARBITRATION, YOU WAIVE YOUR RIGHT TO LITIGATE DISPUTES THROUGH A COURT AND TO HAVE A JUDGE OR JURY DECIDE YOUR CASE.",
+            "marks": [
+              {
+                "type": "bold"
+              }
+            ],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-3",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "14.4.1. General",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "You and JustFix agree that any legal or equitable claim, dispute, action, or proceeding arising from or related to your use of the Services or these Terms (“Dispute”) will be resolved as follows to the fullest extent permitted by law:",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-3",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "14.4.2. Notice of Dispute",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "In the event of a Dispute, you or JustFix must give the other a written statement that sets forth the name, address, and contact information of the party giving it, the facts giving rise to the Dispute, and a proposed solution (a “Notice of Dispute”). You must send any Notice of Dispute by first class U.S. Mail to JustFix at ",
+            "marks": [],
+            "data": {}
+          },
+          {
+            "nodeType": "text",
+            "value": "137 Montague Street, PMB #211, Brooklyn NY 11201",
+            "marks": [],
+            "data": {}
+          },
+          {
+            "nodeType": "text",
+            "value": " with a copy sent to support@justfix.org. JustFix will send any Notice of Dispute to you by first class U.S. Mail to your address if it is in JustFix’s records, or otherwise to your email address. You and JustFix will attempt in good faith to resolve any Dispute through informal negotiation within sixty (60) days from the date of the Notice of Dispute is sent. After sixty (60) days, you or JustFix may commence arbitration.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-3",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "14.4.3. Binding Arbitration",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "Any Dispute which has not been resolved by negotiation as provided herein within sixty (60) days or such time period as you and JustFix may otherwise agree, shall be finally resolved by binding arbitration as described in this Section 14.4. (Dispute Resolution and Arbitration). You are giving up the right to litigate (or participate in as a party or class member) all Disputes in court before a judge or jury. Instead, all Disputes will be resolved before a neutral arbitrator, whose decision will be final except for a limited right of appeal under the Federal Arbitration Act. The place of arbitration shall be New York, NY. Any court with jurisdiction over the parties may enforce the arbitrator’s award.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-3",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "14.4.4. Class Action Waiver",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "Any proceedings to resolve or litigate any Dispute in any forum will be conducted solely on an individual basis. Neither you nor JustFix will seek to have any Dispute heard as a class action or in any other proceeding in which either party acts or proposes to act in a representative capacity. No arbitration or proceeding will be combined with another without the prior written consent of all parties to all affected arbitrations or proceedings. You may file a Dispute only on your own behalf and cannot seek relief that would affect other Users. If there is a final judicial determination that any particular Dispute cannot be arbitrated in accordance with the limitations of this Section 14.4 (Dispute Resolution and Arbitration), then only that Dispute may be severed and brought in court. All other Disputes remain subject to this Section 14.4 (Dispute Resolution and Arbitration).",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-3",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "14.4.5. Arbitration Procedures",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "Any arbitration will be conducted by JAMS under the JAMS Comprehensive Arbitration Rules and Procedures (“JAMS Rules”) in effect at the time the Dispute is filed. You may request a telephonic or in-person hearing by following the JAMS Rules. In a dispute involving $10,000 or less, any hearing will be telephonic unless the arbitrator finds good cause to hold an in-person hearing instead. To the extent the forum provided by JAMS is unavailable, JustFix and you agree to select a mutually agreeable alternative dispute resolution service and that such alternative dispute resolution service shall apply the JAMS Rules. The arbitrator may award the same damages to you individually as a court could. The arbitrator may award declaratory or injunctive relief to you only individually, and only to the extent required to satisfy your individual claim.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-3",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "14.4.6. Arbitration Fees",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "Whoever files the arbitration will pay the initial filing fee. If JustFix files, then JustFix will pay; if you file, then you will pay unless you get a fee waiver under the applicable arbitration rules. Each party will bear the expense of that party’s attorneys, experts, and witnesses, and other expenses, regardless of which party prevails, but a party may recover any or all expenses from another party if the arbitrator, applying applicable law, so determines.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-3",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "14.4.7. Filing Period",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "To the extent permitted by law, any Dispute under these Terms must be filed within one (1) year in an arbitration proceeding. The one-year period begins when the events giving rise to the Dispute first occur.  If a Dispute is not filed within one year, it is permanently barred.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-3",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "14.4.8. Venue",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "In the event that any Dispute cannot be resolved by binding arbitration in accordance with this Section 14.4 (Dispute Resolution and Arbitration), you agree that such Dispute will be filed only in the state or federal courts in and for New York, NY, and each of you and JustFix hereby consent and submit to the personal and exclusive jurisdiction of such courts for the purpose of litigating any such action. Notwithstanding this, JustFix shall still be allowed to apply for injunctive or other equitable relief to protect or enforce its intellectual property rights in any court of competent jurisdiction.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "14.5. Severability",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "If any provision of the Terms or any Guidelines is held to be unlawful, void, or for any reason unenforceable, then that provision will be limited or eliminated from the Terms to the minimum extent necessary and will not affect the validity and enforceability of any remaining provisions.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "14.6. Assignment",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "The Terms and related Guidelines, and any rights and licenses granted hereunder, may not be transferred or assigned by you without JustFix’s prior written consent, but may be assigned by JustFix without consent or any restriction. Any assignment attempted to be made in violation of the Terms shall be null and void.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "14.7. Survival",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "Upon termination of the Terms, any provision which, by its nature or express terms should survive, will survive such termination or expiration, including, but not limited to, Sections 2 (Privacy Policy), 4 (Modification of the Terms) through 5 (Digital Millennium Copyright Act), 6.1 (Proprietary Materials), 6.2 (Non-Commercial Use), and 7 (Prohibited Conduct) through 14 (Miscellaneous (Including Dispute Resolution and Arbitration)).",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "14.8. Headings",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "The heading references herein are for convenience purposes only, do not constitute a part of the Terms, and will not be deemed to limit or affect any of the provisions hereof.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "14.9. Entire Agreement",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "The Terms, the Privacy Policy, and Guidelines constitute the entire agreement between you and JustFix relating to the subject matter herein and will not be modified except in writing, signed by both parties, or by a change to the Terms, Privacy Policy, or Guidelines made by JustFix as set forth in Section 4 (Modification of the Terms) above.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "heading-2",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "14.10. Disclosures",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "The Services are hosted in the United States, and the services provided hereunder are offered by JustFix, located at ",
+            "marks": [],
+            "data": {}
+          },
+          {
+            "nodeType": "text",
+            "value": "137 Montague Street, PMB #211, Brooklyn NY 11201.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      },
+      {
+        "nodeType": "paragraph",
+        "data": {},
+        "content": [
+          {
+            "nodeType": "text",
+            "value": "Effective as of May 13, 2024.",
+            "marks": [],
+            "data": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -113,6 +113,33 @@
   resolved "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.0.2.tgz"
   integrity sha512-NVf/1YycDMs6+FxS0Tb/W8MjJRDQdXF+tBfDtZ5UZeiRUkTmwKc4vmYCKZTyymfJk1gnMsauvZSX/HiV9jOABw==
 
+"@contentful/content-source-maps@^0.11.7":
+  version "0.11.7"
+  resolved "https://registry.yarnpkg.com/@contentful/content-source-maps/-/content-source-maps-0.11.7.tgz#ddb494bdfeeab74169f95eca1dff2a1e7b88c2b6"
+  integrity sha512-f+AVIM/Z+AmCagM+9hDUhhT63WVFJurbqHhzul8KVyPNIJLaUHAfMns+nxgEKCPRtef+rCk7ufaZ3HEUS1ssYQ==
+  dependencies:
+    "@vercel/stega" "^0.1.2"
+    json-pointer "^0.6.2"
+
+"@contentful/rich-text-react-renderer@^16.0.1":
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/@contentful/rich-text-react-renderer/-/rich-text-react-renderer-16.0.1.tgz#9029eac735cdc3dfb5bd83d9e231506b1c66ac32"
+  integrity sha512-7wZZBMgwbq5Udp2KebKCJoh9K+EPGlgRkudhXSp+OxtAIdBC6JUz3Oi9kXXKYKLeSg7iTBpkO1dd0/xFjHHKbg==
+  dependencies:
+    "@contentful/rich-text-types" "^17.0.0"
+
+"@contentful/rich-text-types@^16.6.1":
+  version "16.8.5"
+  resolved "https://registry.yarnpkg.com/@contentful/rich-text-types/-/rich-text-types-16.8.5.tgz#832c8b428612f5181908bc1033c6ef9f48f1ce83"
+  integrity sha512-q18RJuJCOuYveGiCIjE5xLCQc5lZ3L2Qgxrlg/H2YEobDFqdtmklazRi1XwEWaK3tMg6yVXBzKKkQfLB4qW14A==
+
+"@contentful/rich-text-types@^17.0.0":
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/@contentful/rich-text-types/-/rich-text-types-17.0.0.tgz#f58badfe01fa10860e065c02fd584f428a70ecc6"
+  integrity sha512-x50t6sILzFHBdFpAo0foJRnH8fHWyidheWhAv3uwt9aOnNqTh893gxyoc3Q0RVEZxXfHpTi+O9gmakHcdlRdTA==
+  dependencies:
+    is-plain-obj "^3.0.0"
+
 "@emotion/babel-plugin@^11.12.0":
   version "11.12.0"
   resolved "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.12.0.tgz"
@@ -558,6 +585,11 @@
   version "4.21.3"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.21.3.tgz#5226cde6c6b495b04a3392c1d2c572844e42f06b"
   integrity sha512-kZPbX/NOPh0vhS5sI+dR8L1bU2cSO9FgxwM8r7wHzGydzfSjLRCFAT87GR5U9scj2rhzN3JPYVC7NoBbl4FZ0g==
+
+"@rollup/rollup-linux-x64-gnu@^4.18.0":
+  version "4.31.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.31.0.tgz#c6b048f1e25f3fea5b4bd246232f4d07a159c5a0"
+  integrity sha512-zSoHl356vKnNxwOWnLd60ixHNPRBglxpv2g7q0Cd3Pmr561gf0HiAcUBRL3S1vPqRC17Zo2CX/9cPkqTIiai1g==
 
 "@rollup/rollup-linux-x64-musl@4.21.3":
   version "4.21.3"
@@ -1203,6 +1235,11 @@
     "@typescript-eslint/types" "8.6.0"
     eslint-visitor-keys "^3.4.3"
 
+"@vercel/stega@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@vercel/stega/-/stega-0.1.2.tgz#0c20c5c9419c4288b1de58a64b5f9f26c763b25f"
+  integrity sha512-P7mafQXjkrsoyTRppnt0N21udKS9wUmLXHRyP9saLXLHw32j/FgUJ3FscSWgvSqRs4cj7wKZtwqJEvWJ2jbGmA==
+
 "@vitejs/plugin-react-swc@^3.5.0":
   version "3.7.0"
   resolved "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.7.0.tgz"
@@ -1292,6 +1329,15 @@ axios@^1.4.0:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
+axios@^1.7.9:
+  version "1.7.9"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.9.tgz#d7d071380c132a24accda1b2cfc1535b79ec650a"
+  integrity sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 babel-plugin-macros@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz"
@@ -1349,6 +1395,22 @@ buffer@^5.5.0:
   dependencies:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
+
+call-bind-apply-helpers@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz#32e5892e6361b29b0b545ba6f7763378daca2840"
+  integrity sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==
+  dependencies:
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
+
+call-bound@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/call-bound/-/call-bound-1.0.3.tgz#41cfd032b593e39176a71533ab4f384aa04fd681"
+  integrity sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==
+  dependencies:
+    call-bind-apply-helpers "^1.0.1"
+    get-intrinsic "^1.2.6"
 
 callsites@^3.0.0:
   version "3.1.0"
@@ -1454,6 +1516,39 @@ console-polyfill@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/console-polyfill/-/console-polyfill-0.3.0.tgz#84900902a18c47a5eba932be75fa44d23e8af861"
   integrity sha512-w+JSDZS7XML43Xnwo2x5O5vxB0ID7T5BdqDtyqT6uiCAX2kZAgcWxNaGqT97tZfSHzfOcvrfsDAodKcJ3UvnXQ==
+
+contentful-resolve-response@^1.9.0:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/contentful-resolve-response/-/contentful-resolve-response-1.9.2.tgz#a341e84aabb16c871fea37073e6d890e0e2513fb"
+  integrity sha512-VTY1hZGh29yspBeveJ62cuDf+cw9Iq/NcKWBdNHjTq8hvgxz+E19+Pej3LW/02o98+D0XcKfcPYXIpm4lHY+eg==
+  dependencies:
+    fast-copy "^2.1.7"
+
+contentful-sdk-core@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/contentful-sdk-core/-/contentful-sdk-core-9.0.1.tgz#13460882fe58a0e507227831f5596c6d9f27233e"
+  integrity sha512-Ao/5Y74ERPn6kjzb/8okYPuQJnikMtR+dnv0plLw8IvPomwXonLq3qom0rLSyo5KuvQkBMa9AApy1izunxW4mw==
+  dependencies:
+    fast-copy "^3.0.2"
+    lodash "^4.17.21"
+    p-throttle "^6.1.0"
+    process "^0.11.10"
+    qs "^6.12.3"
+  optionalDependencies:
+    "@rollup/rollup-linux-x64-gnu" "^4.18.0"
+
+contentful@^11.4.4:
+  version "11.4.4"
+  resolved "https://registry.yarnpkg.com/contentful/-/contentful-11.4.4.tgz#1e55f516977f801f4be38a27d423a133eee11503"
+  integrity sha512-umCr2VKyxFe7YhvFD8XwmRFbsg+cK9VdQq8AjQiHNQs+RDlRV/olBgA8JaaUVeLLVf/E6OO9nRr0RZVWpOVO1w==
+  dependencies:
+    "@contentful/content-source-maps" "^0.11.7"
+    "@contentful/rich-text-types" "^16.6.1"
+    axios "^1.7.9"
+    contentful-resolve-response "^1.9.0"
+    contentful-sdk-core "^9.0.1"
+    json-stringify-safe "^5.0.1"
+    type-fest "^4.0.0"
 
 convert-source-map@^1.5.0:
   version "1.9.0"
@@ -1571,6 +1666,15 @@ drange@^1.0.2:
   resolved "https://registry.npmjs.org/drange/-/drange-1.1.1.tgz"
   integrity sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA==
 
+dunder-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
+  integrity sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==
+  dependencies:
+    call-bind-apply-helpers "^1.0.1"
+    es-errors "^1.3.0"
+    gopd "^1.2.0"
+
 end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.4"
   resolved "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz"
@@ -1591,6 +1695,23 @@ error-stack-parser@^2.0.4:
   integrity sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==
   dependencies:
     stackframe "^1.3.4"
+
+es-define-property@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
+  integrity sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==
+
+es-errors@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
+  integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
+
+es-object-atoms@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
+  integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
+  dependencies:
+    es-errors "^1.3.0"
 
 esbuild@^0.21.3:
   version "0.21.5"
@@ -1737,6 +1858,16 @@ expand-template@^2.0.3:
   resolved "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz"
   integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
 
+fast-copy@^2.1.7:
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-2.1.7.tgz#affc9475cb4b555fb488572b2a44231d0c9fa39e"
+  integrity sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA==
+
+fast-copy@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-3.0.2.tgz#59c68f59ccbcac82050ba992e0d5c389097c9d35"
+  integrity sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
@@ -1834,6 +1965,11 @@ follow-redirects@^1.15.6:
   resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz"
   integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
 
+foreach@^2.0.4:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.6.tgz#87bcc8a1a0e74000ff2bf9802110708cfb02eb6e"
+  integrity sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg==
+
 form-data@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz"
@@ -1862,6 +1998,30 @@ function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
+
+get-intrinsic@^1.2.5, get-intrinsic@^1.2.6:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.7.tgz#dcfcb33d3272e15f445d15124bc0a216189b9044"
+  integrity sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==
+  dependencies:
+    call-bind-apply-helpers "^1.0.1"
+    es-define-property "^1.0.1"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.0.0"
+    function-bind "^1.1.2"
+    get-proto "^1.0.0"
+    gopd "^1.2.0"
+    has-symbols "^1.1.0"
+    hasown "^2.0.2"
+    math-intrinsics "^1.1.0"
+
+get-proto@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-proto/-/get-proto-1.0.1.tgz#150b3f2743869ef3e851ec0c49d15b1d14d00ee1"
+  integrity sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==
+  dependencies:
+    dunder-proto "^1.0.1"
+    es-object-atoms "^1.0.0"
 
 github-from-package@0.0.0:
   version "0.0.0"
@@ -1897,6 +2057,11 @@ globals@^15.9.0:
   resolved "https://registry.npmjs.org/globals/-/globals-15.9.0.tgz"
   integrity sha512-SmSKyLLKFbSr6rptvP8izbyxJL4ILwqO9Jg23UA0sDlGlu58V59D1//I3vlc0KJphVdUR7vMjHIplYnzBxorQA==
 
+gopd@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
+  integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
+
 graphemer@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz"
@@ -1911,6 +2076,11 @@ has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+has-symbols@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
+  integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
 
 hasown@^2.0.2:
   version "2.0.2"
@@ -2054,6 +2224,11 @@ is-path-inside@^3.0.3:
   resolved "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz"
   integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
 
+is-plain-obj@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-3.0.0.tgz#af6f2ea14ac5a646183a5bbdb5baabbc156ad9d7"
+  integrity sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
@@ -2091,6 +2266,13 @@ json-parse-even-better-errors@^2.3.0:
   resolved "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
 
+json-pointer@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/json-pointer/-/json-pointer-0.6.2.tgz#f97bd7550be5e9ea901f8c9264c9d436a22a93cd"
+  integrity sha512-vLWcKbOaXlO+jvRy4qNd+TI1QUPZzfJj1tpJ3vAXDych5XJf93ftpUKe5pKCrzyIIwgBJcOcCVRUfqQP25afBw==
+  dependencies:
+    foreach "^2.0.4"
+
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz"
@@ -2101,7 +2283,7 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
-json-stringify-safe@~5.0.0:
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
@@ -2167,6 +2349,11 @@ lru-cache@~2.2.1:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.2.4.tgz#6c658619becf14031d0d0b594b16042ce4dc063d"
   integrity sha512-Q5pAgXs+WEAfoEdw2qKQhNFFhMoFMTYqRVKKUMnzuiR7oKFHS7fWo848cPcTKw+4j/IdN17NyzdhVKgabFV0EA==
+
+math-intrinsics@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
+  integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
 
 memoize-one@^6.0.0:
   version "6.0.0"
@@ -2301,6 +2488,11 @@ object-assign@^4.1.1:
   resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
+object-inspect@^1.13.3:
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.3.tgz#f14c183de51130243d6d18ae149375ff50ea488a"
+  integrity sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==
+
 once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
@@ -2347,6 +2539,11 @@ p-locate@^5.0.0:
   integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
   dependencies:
     p-limit "^3.0.2"
+
+p-throttle@^6.1.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/p-throttle/-/p-throttle-6.2.0.tgz#bc75ff1f128680bec15568cbf7312ae34a9d35ed"
+  integrity sha512-NCKkOVj6PZa6NiTmfvGilDdf6vO1rFCD3KDnkHko8dTOtkpk4cSR/VTAhhLMG9aiQ7/A9HYgEDNmxzf6hxzR3g==
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -2492,6 +2689,13 @@ punycode@^2.1.0:
   version "2.3.1"
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
+
+qs@^6.12.3:
+  version "6.14.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.0.tgz#c63fa40680d2c5c941412a0e899c89af60c0a930"
+  integrity sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==
+  dependencies:
+    side-channel "^1.1.0"
 
 querystringify@^2.1.1:
   version "2.2.0"
@@ -2845,6 +3049,46 @@ short-unique-id@^5.0.2:
   resolved "https://registry.npmjs.org/short-unique-id/-/short-unique-id-5.2.0.tgz"
   integrity sha512-cMGfwNyfDZ/nzJ2k2M+ClthBIh//GlZl1JEf47Uoa9XR11bz8Pa2T2wQO4bVrRdH48LrIDWJahQziKo3MjhsWg==
 
+side-channel-list@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/side-channel-list/-/side-channel-list-1.0.0.tgz#10cb5984263115d3b7a0e336591e290a830af8ad"
+  integrity sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==
+  dependencies:
+    es-errors "^1.3.0"
+    object-inspect "^1.13.3"
+
+side-channel-map@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/side-channel-map/-/side-channel-map-1.0.1.tgz#d6bb6b37902c6fef5174e5f533fab4c732a26f42"
+  integrity sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==
+  dependencies:
+    call-bound "^1.0.2"
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.5"
+    object-inspect "^1.13.3"
+
+side-channel-weakmap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz#11dda19d5368e40ce9ec2bdc1fb0ecbc0790ecea"
+  integrity sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==
+  dependencies:
+    call-bound "^1.0.2"
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.5"
+    object-inspect "^1.13.3"
+    side-channel-map "^1.0.1"
+
+side-channel@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.1.0.tgz#c3fcff9c4da932784873335ec9765fa94ff66bc9"
+  integrity sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==
+  dependencies:
+    es-errors "^1.3.0"
+    object-inspect "^1.13.3"
+    side-channel-list "^1.0.0"
+    side-channel-map "^1.0.1"
+    side-channel-weakmap "^1.0.2"
+
 simple-concat@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz"
@@ -3115,6 +3359,11 @@ type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
+type-fest@^4.0.0:
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.33.0.tgz#2da0c135b9afa76cf8b18ecfd4f260ecd414a432"
+  integrity sha512-s6zVrxuyKbbAsSAD5ZPTB77q4YIdRctkTbJ2/Dqlinwz+8ooH2gd+YA7VA6Pa93KML9GockVvoxjZ2vHP+mu8g==
 
 types-ramda@^0.30.1:
   version "0.30.1"


### PR DESCRIPTION
This copies over our privacy policy and terms of use pages from WOW. I follow the same set up as WOW - where we download static copies of the contentful pages and use contentful packages to render the elements. I made only a couple small edits to the data files to adjust the title and links. I didn't do a lot with the styles, but just adjusted some of the heading styles since these pages use a mix of many header levels. 
One issue is that the contentful data uses headings up to level 1, but our own page titles are 2, so this breaks some a11y rules. I think the only solution would be to better standardize things on contentful to start at 3, but not sure this is necessary.

[sc-16106]