### PR TITLE
add user url param for guide page

### DIFF
--- a/src/Components/Pages/PortfolioSize/PortfolioSize.tsx
+++ b/src/Components/Pages/PortfolioSize/PortfolioSize.tsx
@@ -11,7 +11,11 @@ import { Accordion } from "../../Accordion/Accordion";
 import { FormFields } from "../Form/Survey";
 import JFCLLinkExternal from "../../JFCLLinkExternal";
 import { useGetBuildingData } from "../../../api/hooks";
-import { AcrisDocument, BuildingData } from "../../../types/APIDataTypes";
+import {
+  AcrisDocument,
+  BuildingData,
+  GCEUser,
+} from "../../../types/APIDataTypes";
 import {
   acrisDocTypeFull,
   closeAccordionsPrint,
@@ -34,7 +38,8 @@ const EMAIL_SUBJECT =
 const EMAIL_BODY = "...";
 
 export const PortfolioSize: React.FC = () => {
-  const { address, fields } = useLoaderData() as {
+  const { user, address, fields } = useLoaderData() as {
+    user: GCEUser;
     address: Address;
     fields: FormFields;
   };
@@ -44,7 +49,11 @@ export const PortfolioSize: React.FC = () => {
     // save session state in params
     if (address && fields) {
       setSearchParams(
-        { address: JSON.stringify(address), fields: JSON.stringify(fields) },
+        {
+          ...(!!user?.id && { user: JSON.stringify(user.id) }),
+          address: JSON.stringify(address),
+          fields: JSON.stringify(fields),
+        },
         { replace: true }
       );
     }


### PR DESCRIPTION
Previously I left tout the user from the URL params for portfolio guide page. We want the user id to be included ust like the result page in case people want to save the link to return later and complete the research so we can update their results in the db