### PR TITLE
add separate live-in landlord criteria and condition question

### DIFF
--- a/src/Components/Pages/Form/Survey.tsx
+++ b/src/Components/Pages/Form/Survey.tsx
@@ -19,18 +19,19 @@ import { BackLink } from "../../JFCLLinkInternal";
 export type FormFields = {
   bedrooms: "STUDIO" | "1" | "2" | "3" | "4+" | null;
   rent: string | null;
-  landlord: "YES" | "NO" | "UNSURE" | null;
   rentStabilized: "YES" | "NO" | "UNSURE" | null;
   housingType: "NYCHA" | "SUBSIDIZED" | "NONE" | "UNSURE" | null;
+  landlord?: "YES" | "NO" | null;
   portfolioSize?: "YES" | "NO" | "UNSURE" | null;
 };
 
+// This must be in the order that the questions appear
 const initialFields: FormFields = {
   bedrooms: null,
   rent: null,
-  landlord: null,
   rentStabilized: null,
   housingType: null,
+  landlord: null,
   portfolioSize: null,
 };
 
@@ -59,7 +60,8 @@ export const Survey: React.FC = () => {
   const { trigger } = useSendGceData();
   const rollbar = useRollbar();
 
-  const NUM_STEPS = !bldgData ? 5 : bldgData?.unitsres > 10 ? 5 : 6;
+  // Skip live-in landlord and portfolio size questions is > 10 units
+  const NUM_STEPS = !bldgData ? 4 : bldgData?.unitsres > 10 ? 4 : 6;
 
   const formStepRefs = [
     useRef<HTMLFieldSetElement | null>(null),
@@ -76,6 +78,7 @@ export const Survey: React.FC = () => {
     const firstUnansweredIndex = Object.values(localFields).findIndex(
       (x) => x === null
     );
+    console.log({ NUM_STEPS, firstUnansweredIndex });
     if (firstUnansweredIndex >= 0 && firstUnansweredIndex <= NUM_STEPS - 1) {
       setShowErrors(true);
       formStepRefs[firstUnansweredIndex].current?.scrollIntoView({
@@ -192,32 +195,6 @@ export const Survey: React.FC = () => {
               step={3}
               total={NUM_STEPS}
               fieldsetRef={formStepRefs[2]}
-              invalid={showErrors && localFields.landlord === null}
-            >
-              <FormGroup
-                legendText="Does your landlord live in the building?"
-                invalid={showErrors && localFields.landlord === null}
-                invalidText="Please select one"
-              >
-                <RadioGroup
-                  fields={localFields}
-                  radioGroup={{
-                    name: "landlord",
-                    options: [
-                      { label: "Yes", value: "YES" },
-                      { label: "No", value: "NO" },
-                      { label: "I'm not sure", value: "UNSURE" },
-                    ],
-                  }}
-                  onChange={handleRadioChange}
-                />
-              </FormGroup>
-            </FormStep>
-
-            <FormStep
-              step={4}
-              total={NUM_STEPS}
-              fieldsetRef={formStepRefs[3]}
               invalid={showErrors && localFields.rentStabilized === null}
             >
               <FormGroup
@@ -246,9 +223,9 @@ export const Survey: React.FC = () => {
             </FormStep>
 
             <FormStep
-              step={5}
+              step={4}
               total={NUM_STEPS}
-              fieldsetRef={formStepRefs[4]}
+              fieldsetRef={formStepRefs[3]}
               invalid={showErrors && localFields.housingType === null}
             >
               <FormGroup
@@ -278,38 +255,65 @@ export const Survey: React.FC = () => {
             </FormStep>
 
             {bldgData && bldgData?.unitsres <= 10 && (
-              <FormStep
-                step={6}
-                total={NUM_STEPS}
-                fieldsetRef={formStepRefs[5]}
-                invalid={showErrors && localFields.portfolioSize === null}
-              >
-                <FormGroup
-                  legendText="Does your landlord own more than 10 apartments across multiple buildings?"
-                  helperElement={
-                    <InfoBox>
-                      {`It looks like there are ${bldgData.unitsres} apartments in your building. ` +
-                        "Good Cause Eviction protections only apply to tenants whose landlords own more than 10 apartments, " +
-                        "even if those apartments are spread across multiple buildings."}
-                    </InfoBox>
-                  }
-                  invalid={showErrors && localFields.portfolioSize === null}
-                  invalidText="Please select one"
+              <>
+                <FormStep
+                  step={5}
+                  total={NUM_STEPS}
+                  fieldsetRef={formStepRefs[4]}
+                  invalid={showErrors && localFields.landlord === null}
                 >
-                  <RadioGroup
-                    fields={localFields}
-                    radioGroup={{
-                      name: "portfolioSize",
-                      options: [
-                        { label: "Yes", value: "YES" },
-                        { label: "No", value: "NO" },
-                        { label: "I'm not sure", value: "UNSURE" },
-                      ],
-                    }}
-                    onChange={handleRadioChange}
-                  />
-                </FormGroup>
-              </FormStep>
+                  <FormGroup
+                    legendText="Does your landlord live in the building?"
+                    invalid={showErrors && localFields.landlord === null}
+                    invalidText="Please select one"
+                  >
+                    <RadioGroup
+                      fields={localFields}
+                      radioGroup={{
+                        name: "landlord",
+                        options: [
+                          { label: "Yes", value: "YES" },
+                          { label: "No", value: "NO" },
+                        ],
+                      }}
+                      onChange={handleRadioChange}
+                    />
+                  </FormGroup>
+                </FormStep>
+
+                <FormStep
+                  step={6}
+                  total={NUM_STEPS}
+                  fieldsetRef={formStepRefs[5]}
+                  invalid={showErrors && localFields.portfolioSize === null}
+                >
+                  <FormGroup
+                    legendText="Does your landlord own more than 10 apartments across multiple buildings?"
+                    helperElement={
+                      <InfoBox>
+                        {`It looks like there are ${bldgData.unitsres} apartments in your building. ` +
+                          "Good Cause Eviction protections only apply to tenants whose landlords own more than 10 apartments, " +
+                          "even if those apartments are spread across multiple buildings."}
+                      </InfoBox>
+                    }
+                    invalid={showErrors && localFields.portfolioSize === null}
+                    invalidText="Please select one"
+                  >
+                    <RadioGroup
+                      fields={localFields}
+                      radioGroup={{
+                        name: "portfolioSize",
+                        options: [
+                          { label: "Yes", value: "YES" },
+                          { label: "No", value: "NO" },
+                          { label: "I'm not sure", value: "UNSURE" },
+                        ],
+                      }}
+                      onChange={handleRadioChange}
+                    />
+                  </FormGroup>
+                </FormStep>
+              </>
             )}
           </form>
           <div className="form__buttons">

--- a/src/Components/Pages/Form/Survey.tsx
+++ b/src/Components/Pages/Form/Survey.tsx
@@ -78,7 +78,6 @@ export const Survey: React.FC = () => {
     const firstUnansweredIndex = Object.values(localFields).findIndex(
       (x) => x === null
     );
-    console.log({ NUM_STEPS, firstUnansweredIndex });
     if (firstUnansweredIndex >= 0 && firstUnansweredIndex <= NUM_STEPS - 1) {
       setShowErrors(true);
       formStepRefs[firstUnansweredIndex].current?.scrollIntoView({

--- a/src/Components/Pages/Results/Results.tsx
+++ b/src/Components/Pages/Results/Results.tsx
@@ -207,6 +207,7 @@ export const Results: React.FC = () => {
 const CRITERIA_LABELS = {
   portfolioSize: "Landlord portfolio size",
   buildingClass: "Type of building",
+  landlord: "Live-in Landlord",
   rent: "Rent",
   subsidy: "Subsidy",
   rentStabilized: "Rent stabilization",
@@ -295,6 +296,7 @@ const CriteriaTable: React.FC<{
         <CriterionRow {...criteria.certificateOfOccupancy} />
       )}
       {criteria?.subsidy && <CriterionRow {...criteria.subsidy} />}
+      {criteria?.landlord && <CriterionRow {...criteria.landlord} />}
       {criteria?.portfolioSize && <CriterionRow {...criteria.portfolioSize} />}
     </ul>
     <ContentBoxFooter

--- a/src/hooks/eligibility.tsx
+++ b/src/hooks/eligibility.tsx
@@ -2,10 +2,17 @@ import { FormFields } from "../Components/Pages/Form/Survey";
 import JFCLLinkInternal from "../Components/JFCLLinkInternal";
 import { BuildingData, CriterionResult } from "../types/APIDataTypes";
 import JFCLLinkExternal from "../Components/JFCLLinkExternal";
-import { urlDOBBBL, urlDOBBIN, urlFCSubsidized, urlZOLA } from "../helpers";
+import {
+  formatNumber,
+  urlDOBBBL,
+  urlDOBBIN,
+  urlFCSubsidized,
+  urlZOLA,
+} from "../helpers";
 
 export type Criteria =
   | "portfolioSize"
+  | "landlord"
   | "buildingClass"
   | "rent"
   | "subsidy"
@@ -26,6 +33,7 @@ export type CriteriaDetails = {
   rentStabilized: CriterionDetails;
   portfolioSize?: CriterionDetails;
   buildingClass?: CriterionDetails;
+  landlord?: CriterionDetails;
   subsidy?: CriterionDetails;
   certificateOfOccupancy?: CriterionDetails;
 };
@@ -38,6 +46,7 @@ export function useCriteriaResults(
   const criteriaData: CriteriaData = { ...formFields, ...bldgData };
   return {
     portfolioSize: eligibilityPortfolioSize(criteriaData),
+    landlord: eligibilityLandlord(criteriaData),
     buildingClass: eligibilityBuildingClass(criteriaData),
     rent: eligibilityRent(criteriaData),
     rentStabilized: eligibilityRentStabilized(criteriaData),
@@ -49,8 +58,7 @@ export function useCriteriaResults(
 function eligibilityPortfolioSize(
   criteriaData: CriteriaData
 ): CriterionDetails {
-  const { unitsres, related_properties, landlord, portfolioSize, bbl } =
-    criteriaData;
+  const { unitsres, related_properties, portfolioSize } = criteriaData;
   const relatedProperties = related_properties.length || 0;
 
   const criteria = "portfolioSize";
@@ -60,22 +68,11 @@ function eligibilityPortfolioSize(
 
   if (unitsres === undefined) {
     determination = "UNKNOWN";
-    userValue = "No data available for number of apartments in your building.";
+    userValue =
+      "No data available for the number of apartments in your building.";
   } else if (unitsres > 10) {
     determination = "ELIGIBLE";
-    userValue = (
-      <>
-        Your building has more than 10 apartments.
-        <br />
-        <JFCLLinkExternal href={urlZOLA(bbl)} className="criteria-link">
-          View source
-        </JFCLLinkExternal>
-      </>
-    );
-  } else if (landlord === "YES") {
-    determination = "INELIGIBLE";
-    userValue =
-      "Your building has 10 or fewer apartments and is owner-occupied";
+    userValue = "Your building has more than 10 apartments.";
   } else if (portfolioSize === "YES") {
     determination = "ELIGIBLE";
     userValue =
@@ -83,33 +80,70 @@ function eligibilityPortfolioSize(
       "landlord owns more than 10 apartments across multiple buildings.";
   } else if (portfolioSize === "NO") {
     determination = "INELIGIBLE";
-    userValue = (
-      <>
-        Your building has 10 or fewer apartments, and you reported that your
-        landlord does not own other buildings.
-        <br />
-        <JFCLLinkExternal href={urlZOLA(bbl)} className="criteria-link">
-          View source
-        </JFCLLinkExternal>
-      </>
-    );
+    userValue =
+      "Your building has 10 or fewer apartments, and you reported " +
+      "that your landlord does not own other buildings.";
   } else {
     determination = "UNKNOWN";
-    if (relatedProperties) {
-      userValue = (
-        <>
-          {`Your building has only ${unitsres} apartments, but your landlord may own
-          ${relatedProperties - 1} other buildings`}
-          <br />
-          <JFCLLinkInternal to="/portfolio_size" className="criteria-link">
-            Find your landlord’s other buildings
-          </JFCLLinkInternal>
-        </>
-      );
-    } else {
-      userValue = `Your building has only ${unitsres} apartments, but your landlord may own other buildings`;
-    }
+    userValue = (
+      <>
+        {`Your building has only ${unitsres} apartments, but your landlord may own
+          ${
+            relatedProperties ? `${relatedProperties - 1} ` : ""
+          }other buildings`}
+        <br />
+        <JFCLLinkInternal to="/portfolio_size" className="criteria-link">
+          Find your landlord’s other buildings
+        </JFCLLinkInternal>
+      </>
+    );
   }
+
+  return {
+    criteria,
+    determination,
+    requirement,
+    userValue,
+  };
+}
+
+function eligibilityLandlord(criteriaData: CriteriaData): CriterionDetails {
+  const { unitsres, landlord, bbl } = criteriaData;
+
+  const criteria = "landlord";
+  const requirement =
+    "If the building has 10 or fewer apartments, the landlord must not also live in it.";
+  let determination: CriterionResult;
+  let userValueText: string;
+
+  if (unitsres === undefined) {
+    determination = "UNKNOWN";
+    userValueText =
+      "No data available for the number of apartments in your building.";
+  } else if (unitsres > 10) {
+    determination = "ELIGIBLE";
+    userValueText = `Your building has ${formatNumber(unitsres)} apartments.`;
+  } else if (landlord === "YES") {
+    determination = "INELIGIBLE";
+    userValueText = `Your building has ${formatNumber(
+      unitsres
+    )} apartments and you reported that your landlord lives in the building.`;
+  } else {
+    determination = "ELIGIBLE";
+    userValueText = `Your building has ${formatNumber(
+      unitsres
+    )} apartments and you reported that your landlord does not live in the building.`;
+  }
+
+  const userValue = (
+    <>
+      {userValueText}
+      <br />
+      <JFCLLinkExternal href={urlZOLA(bbl)} className="criteria-link">
+        View source
+      </JFCLLinkExternal>
+    </>
+  );
 
   return {
     criteria,

--- a/src/hooks/eligibility.tsx
+++ b/src/hooks/eligibility.tsx
@@ -72,22 +72,24 @@ function eligibilityPortfolioSize(
       "No data available for the number of apartments in your building.";
   } else if (unitsres > 10) {
     determination = "ELIGIBLE";
-    userValue = "Your building has more than 10 apartments.";
+    userValue = `Your building has ${formatNumber(unitsres)} apartments.`;
   } else if (portfolioSize === "YES") {
     determination = "ELIGIBLE";
-    userValue =
-      "Your building has 10 or fewer apartments, and you reported that your " +
-      "landlord owns more than 10 apartments across multiple buildings.";
+    userValue = `Your building has ${formatNumber(
+      unitsres
+    )} apartments, and you reported that your landlord owns more than 10 apartments across multiple buildings.`;
   } else if (portfolioSize === "NO") {
     determination = "INELIGIBLE";
-    userValue =
-      "Your building has 10 or fewer apartments, and you reported " +
-      "that your landlord does not own other buildings.";
+    userValue = `Your building has ${formatNumber(
+      unitsres
+    )} apartments, and you reported that your landlord does not own other buildings.`;
   } else {
     determination = "UNKNOWN";
     userValue = (
       <>
-        {`Your building has only ${unitsres} apartments, but your landlord may own
+        {`Your building has only ${formatNumber(
+          unitsres
+        )} apartments, but your landlord may own
           ${
             relatedProperties ? `${relatedProperties - 1} ` : ""
           }other buildings`}


### PR DESCRIPTION
* We remove the "unsure" option for the landlord question. 
* The landlord survey question is now only shown when building units <= 10 (like portfolio size)
* Separate landlord logic from the portfolio size criteria into it's own eligibility criteria row in the table

[sc-16156]