### PR TITLE
Fixes for a few issues from functional QA

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,9 +20,9 @@ import { Footer } from "./Components/Footer/Footer";
 import { TenantRights } from "./Components/Pages/TenantRights/TenantRights";
 import { TopBar } from "./Components/TopBar/TopBar";
 import { NetworkError } from "./api/error-reporting";
-import "./App.scss";
 import { PrivacyPolicy } from "./Components/Pages/Legal/PrivacyPolicy";
 import { TermsOfUse } from "./Components/Pages/Legal/TermsOfUse";
+import "./App.scss";
 
 const Layout = () => {
   return (
@@ -122,7 +122,7 @@ const router = createBrowserRouter(
       <Route
         path="rent_stabilization"
         element={<RentStabilization />}
-        loader={LoadAddressAndUserSession}
+        loader={LoadURLSession}
       />
       <Route
         path="portfolio_size"

--- a/src/Components/Footer/Footer.tsx
+++ b/src/Components/Footer/Footer.tsx
@@ -9,7 +9,7 @@ export const Footer: React.FC = () => (
         qualified to give advice on legal issues pertaining to housing. We can
         help direct you to free legal services if necessary.
       </div>
-      <div className="footer__legal_pages">
+      <nav className="footer__legal_pages">
         <a
           href="privacy_policy"
           target="_blank"
@@ -26,7 +26,7 @@ export const Footer: React.FC = () => (
         >
           Terms of Use
         </a>
-      </div>
+      </nav>
     </div>
   </footer>
 );

--- a/src/Components/Header/Header.tsx
+++ b/src/Components/Header/Header.tsx
@@ -38,9 +38,9 @@ export const Header: React.FC<HeaderProps> = ({
           )}
         </div>
         {isGuide && (
-          <div className="headline-section__back-link">
+          <nav className="headline-section__back-link">
             <BackLink to="/results">Back to Result</BackLink>
-          </div>
+          </nav>
         )}
         {showProgressBar && (
           <ProgressBar address={address} lastStepReached={lastStepReached} />

--- a/src/Components/Pages/PortfolioSize/PortfolioSize.tsx
+++ b/src/Components/Pages/PortfolioSize/PortfolioSize.tsx
@@ -18,9 +18,7 @@ import {
 } from "../../../types/APIDataTypes";
 import {
   acrisDocTypeFull,
-  closeAccordionsPrint,
   getPrioritizeBldgs,
-  openAccordionsPrint,
   urlAcrisBbl,
   urlAcrisDoc,
   urlCountyClerkBbl,
@@ -29,6 +27,7 @@ import { InfoBox } from "../../InfoBox/InfoBox";
 import { Header } from "../../Header/Header";
 import { ShareButtons } from "../../ShareButtons/ShareButtons";
 import "./PortfolioSize.scss";
+import { useAccordionsOpenForPrint } from "../../../hooks/useAccordionsOpenForPrint";
 
 // const LOOM_EMBED_URL =
 //   "https://www.loom.com/embed/cef3632773a14617a0e8ec407c77e513?sid=93a986f7-ccdc-4048-903c-974fed826119";
@@ -45,6 +44,8 @@ export const PortfolioSize: React.FC = () => {
   };
   const [, setSearchParams] = useSearchParams();
 
+  useAccordionsOpenForPrint();
+
   useEffect(() => {
     // save session state in params
     if (address && fields) {
@@ -58,15 +59,6 @@ export const PortfolioSize: React.FC = () => {
       );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useEffect(() => {
-    window.addEventListener("beforeprint", openAccordionsPrint);
-    window.addEventListener("afterprint", closeAccordionsPrint);
-    return () => {
-      window.removeEventListener("beforeprint", openAccordionsPrint);
-      window.removeEventListener("afterprint", closeAccordionsPrint);
-    };
   }, []);
 
   const bbl = address.bbl;

--- a/src/Components/Pages/PortfolioSize/PortfolioSize.tsx
+++ b/src/Components/Pages/PortfolioSize/PortfolioSize.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useLoaderData, useSearchParams } from "react-router-dom";
 
 import { Address } from "../Home/Home";
@@ -26,8 +26,9 @@ import {
 import { InfoBox } from "../../InfoBox/InfoBox";
 import { Header } from "../../Header/Header";
 import { ShareButtons } from "../../ShareButtons/ShareButtons";
-import "./PortfolioSize.scss";
 import { useAccordionsOpenForPrint } from "../../../hooks/useAccordionsOpenForPrint";
+import { useSearchParamsURL } from "../../../hooks/useSearchParamsURL";
+import "./PortfolioSize.scss";
 
 // const LOOM_EMBED_URL =
 //   "https://www.loom.com/embed/cef3632773a14617a0e8ec407c77e513?sid=93a986f7-ccdc-4048-903c-974fed826119";
@@ -38,28 +39,14 @@ const EMAIL_BODY = "...";
 
 export const PortfolioSize: React.FC = () => {
   const { user, address, fields } = useLoaderData() as {
-    user: GCEUser;
+    user?: GCEUser;
     address: Address;
     fields: FormFields;
   };
   const [, setSearchParams] = useSearchParams();
 
   useAccordionsOpenForPrint();
-
-  useEffect(() => {
-    // save session state in params
-    if (address && fields) {
-      setSearchParams(
-        {
-          ...(!!user?.id && { user: JSON.stringify(user.id) }),
-          address: JSON.stringify(address),
-          fields: JSON.stringify(fields),
-        },
-        { replace: true }
-      );
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  useSearchParamsURL(setSearchParams, address, fields, user);
 
   const bbl = address.bbl;
 

--- a/src/Components/Pages/RentStabilization/RentStabilization.tsx
+++ b/src/Components/Pages/RentStabilization/RentStabilization.tsx
@@ -1,4 +1,4 @@
-import { useLoaderData } from "react-router-dom";
+import { useLoaderData, useSearchParams } from "react-router-dom";
 
 import {
   ContentBox,
@@ -9,19 +9,26 @@ import JFCLLinkExternal from "../../JFCLLinkExternal";
 import { Address } from "../Home/Home";
 import { Header } from "../../Header/Header";
 import { ShareButtons } from "../../ShareButtons/ShareButtons";
-import "./RentStabilization.scss";
 import { useAccordionsOpenForPrint } from "../../../hooks/useAccordionsOpenForPrint";
+import { GCEUser } from "../../../types/APIDataTypes";
+import { FormFields } from "../Form/Survey";
+import "./RentStabilization.scss";
+import { useSearchParamsURL } from "../../../hooks/useSearchParamsURL";
 
 const EMAIL_SUBJECT =
   "Good Cause NYC | Find out if your apartment is rent stabilized";
 const EMAIL_BODY = "...";
 
 export const RentStabilization: React.FC = () => {
-  const { address } = useLoaderData() as {
+  const { user, address, fields } = useLoaderData() as {
+    user: GCEUser;
     address: Address;
+    fields: FormFields;
   };
+  const [, setSearchParams] = useSearchParams();
 
   useAccordionsOpenForPrint();
+  useSearchParamsURL(setSearchParams, address, fields, user);
 
   return (
     <div id="rent-stabilization-page">

--- a/src/Components/Pages/RentStabilization/RentStabilization.tsx
+++ b/src/Components/Pages/RentStabilization/RentStabilization.tsx
@@ -8,10 +8,9 @@ import {
 import JFCLLinkExternal from "../../JFCLLinkExternal";
 import { Address } from "../Home/Home";
 import { Header } from "../../Header/Header";
-import { useEffect } from "react";
-import { openAccordionsPrint, closeAccordionsPrint } from "../../../helpers";
 import { ShareButtons } from "../../ShareButtons/ShareButtons";
 import "./RentStabilization.scss";
+import { useAccordionsOpenForPrint } from "../../../hooks/useAccordionsOpenForPrint";
 
 const EMAIL_SUBJECT =
   "Good Cause NYC | Find out if your apartment is rent stabilized";
@@ -22,14 +21,7 @@ export const RentStabilization: React.FC = () => {
     address: Address;
   };
 
-  useEffect(() => {
-    window.addEventListener("beforeprint", openAccordionsPrint);
-    window.addEventListener("afterprint", closeAccordionsPrint);
-    return () => {
-      window.removeEventListener("beforeprint", openAccordionsPrint);
-      window.removeEventListener("afterprint", closeAccordionsPrint);
-    };
-  }, []);
+  useAccordionsOpenForPrint();
 
   return (
     <div id="rent-stabilization-page">

--- a/src/Components/Pages/Results/Results.tsx
+++ b/src/Components/Pages/Results/Results.tsx
@@ -33,13 +33,10 @@ import {
 } from "../../KYRContent/KYRContent";
 import { Header } from "../../Header/Header";
 import { useSessionStorage } from "../../../hooks/useSessionStorage";
-import {
-  closeAccordionsPrint,
-  openAccordionsPrint,
-  ProgressStep,
-} from "../../../helpers";
+import { ProgressStep } from "../../../helpers";
 import { ShareButtons } from "../../ShareButtons/ShareButtons";
 import "./Results.scss";
+import { useAccordionsOpenForPrint } from "../../../hooks/useAccordionsOpenForPrint";
 
 export const Results: React.FC = () => {
   const { address, fields, user } = useLoaderData() as {
@@ -65,6 +62,8 @@ export const Results: React.FC = () => {
   const headlineRef = useRef<HTMLSpanElement>(null);
   const EMAIL_SUBJECT = "Good Cause NYC | Your Coverage Result";
   const EMAIL_BODY = headlineRef?.current?.textContent;
+
+  useAccordionsOpenForPrint();
 
   useEffect(() => {
     // save session state in params
@@ -96,15 +95,6 @@ export const Results: React.FC = () => {
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useEffect(() => {
-    window.addEventListener("beforeprint", openAccordionsPrint);
-    window.addEventListener("afterprint", closeAccordionsPrint);
-    return () => {
-      window.removeEventListener("beforeprint", openAccordionsPrint);
-      window.removeEventListener("afterprint", closeAccordionsPrint);
-    };
   }, []);
 
   return (

--- a/src/Components/Pages/Results/Results.tsx
+++ b/src/Components/Pages/Results/Results.tsx
@@ -40,7 +40,6 @@ import {
 } from "../../../helpers";
 import { ShareButtons } from "../../ShareButtons/ShareButtons";
 import "./Results.scss";
-import classNames from "classnames";
 
 export const Results: React.FC = () => {
   const { address, fields, user } = useLoaderData() as {
@@ -320,7 +319,6 @@ const EligibilityNextSteps: React.FC<{
     subsidyUnknown,
     portfolioSizeUnknown,
   ].filter(Boolean).length;
-  const isMobile = window.innerWidth < 599 ? "closed" : "open"; // same as mixin for-phone-only breakpoint
   const unsureIcon = (
     <Icon
       icon="circleExclamation"
@@ -341,7 +339,7 @@ const EligibilityNextSteps: React.FC<{
           <ContentBoxItem
             title="We need to know if your apartment is rent stabilized"
             icon={unsureIcon}
-            className={classNames("next-step", isMobile)}
+            className="next-step"
           >
             <p>
               The Good Cause Eviction law only covers tenants whose apartments
@@ -359,7 +357,7 @@ const EligibilityNextSteps: React.FC<{
           <ContentBoxItem
             title="We need to know if your apartment is part of NYCHA or subsidized housing"
             icon={unsureIcon}
-            className={classNames("next-step", isMobile)}
+            className="next-step"
           >
             <p>
               The Good Cause Eviction law only covers tenants whose apartments
@@ -381,7 +379,7 @@ const EligibilityNextSteps: React.FC<{
           <ContentBoxItem
             title="We need to know if your landlord owns more than 10 units"
             icon={unsureIcon}
-            className={classNames("next-step", isMobile)}
+            className="next-step"
           >
             <p>
               {`Good Cause Eviction law only covers tenants whose landlord owns

--- a/src/Components/Pages/TenantRights/TenantRights.tsx
+++ b/src/Components/Pages/TenantRights/TenantRights.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { ContentBoxFooter } from "../../ContentBox/ContentBox";
 import { Header } from "../../Header/Header";
 import {
@@ -7,18 +6,11 @@ import {
   RentStabilizedProtections,
   UniversalProtections,
 } from "../../KYRContent/KYRContent";
-import { openAccordionsPrint, closeAccordionsPrint } from "../../../helpers";
+import { useAccordionsOpenForPrint } from "../../../hooks/useAccordionsOpenForPrint";
 import "./TenantRights.scss";
 
 export const TenantRights: React.FC = () => {
-  useEffect(() => {
-    window.addEventListener("beforeprint", openAccordionsPrint);
-    window.addEventListener("afterprint", closeAccordionsPrint);
-    return () => {
-      window.removeEventListener("beforeprint", openAccordionsPrint);
-      window.removeEventListener("afterprint", closeAccordionsPrint);
-    };
-  }, []);
+  useAccordionsOpenForPrint();
 
   return (
     <div id="tenant-rights-page">

--- a/src/Components/ProgressBar/ProgressBar.scss
+++ b/src/Components/ProgressBar/ProgressBar.scss
@@ -34,7 +34,7 @@
       letter-spacing: -0.00963rem;
     }
 
-    &.active .progress-bar__step__number {
+    .progress-bar__step__number.visited {
       background-color: $OFF_BLACK;
       color: $OFF_WHITE_100;
     }

--- a/src/Components/ProgressBar/ProgressBar.tsx
+++ b/src/Components/ProgressBar/ProgressBar.tsx
@@ -47,7 +47,7 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
       return Step;
     }
   });
-  return <div id="progress-bar">{progressBarSteps}</div>;
+  return <nav id="progress-bar">{progressBarSteps}</nav>;
 };
 
 const makeProgressSteps = (

--- a/src/Components/ProgressBar/ProgressBar.tsx
+++ b/src/Components/ProgressBar/ProgressBar.tsx
@@ -28,11 +28,15 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
       );
 
     const Step = (
-      <div
-        key={index}
-        className={classNames("progress-bar__step", step.active && "active")}
-      >
-        <div className="progress-bar__step__number">{index + 1}</div>
+      <div key={index} className="progress-bar__step">
+        <div
+          className={classNames(
+            "progress-bar__step__number",
+            index <= lastStepReached && "visited"
+          )}
+        >
+          {index + 1}
+        </div>
         {StepText}
       </div>
     );

--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -1,5 +1,5 @@
 import { FormFields } from "../Components/Pages/Form/Survey";
-import { CriteriaDetails } from "../hooks/eligibility";
+import { CriteriaDetails } from "../hooks/useCriteriaResults";
 import {
   CriteriaResults,
   FormAnswers,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -158,21 +158,3 @@ export const formatMoney = (n: number) =>
     style: "currency",
     currency: "USD",
   }).format(n);
-
-export const openAccordionsPrint = () => {
-  const accordions: NodeListOf<HTMLDetailsElement> =
-    document.body.querySelectorAll("details:not([open])");
-  accordions.forEach((e) => {
-    e.setAttribute("open", "");
-    e.dataset.wasclosed = "";
-  });
-};
-
-export const closeAccordionsPrint = () => {
-  const accordions: NodeListOf<HTMLDetailsElement> =
-    document.body.querySelectorAll("details[data-wasclosed]");
-  accordions.forEach((e) => {
-    e.removeAttribute("open");
-    delete e.dataset.wasclosed;
-  });
-};

--- a/src/hooks/useAccordionsOpenForPrint.ts
+++ b/src/hooks/useAccordionsOpenForPrint.ts
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+
+const openAccordionsPrint = () => {
+  const accordions: NodeListOf<HTMLDetailsElement> =
+    document.body.querySelectorAll("details:not([open])");
+  accordions.forEach((e) => {
+    e.setAttribute("open", "");
+    e.dataset.wasclosed = "";
+  });
+};
+
+const closeAccordionsPrint = () => {
+  const accordions: NodeListOf<HTMLDetailsElement> =
+    document.body.querySelectorAll("details[data-wasclosed]");
+  accordions.forEach((e) => {
+    e.removeAttribute("open");
+    delete e.dataset.wasclosed;
+  });
+};
+
+export const useAccordionsOpenForPrint = () => {
+  useEffect(() => {
+    window.addEventListener("beforeprint", openAccordionsPrint);
+    window.addEventListener("afterprint", closeAccordionsPrint);
+    return () => {
+      window.removeEventListener("beforeprint", openAccordionsPrint);
+      window.removeEventListener("afterprint", closeAccordionsPrint);
+    };
+  }, []);
+};

--- a/src/hooks/useCriteriaResults.tsx
+++ b/src/hooks/useCriteriaResults.tsx
@@ -96,7 +96,10 @@ function eligibilityPortfolioSize(
             relatedProperties ? `${relatedProperties - 1} ` : ""
           }other buildings`}
         <br />
-        <JFCLLinkInternal to={`/portfolio_size?${searchParams.toString()}`} className="criteria-link">
+        <JFCLLinkInternal
+          to={`/portfolio_size?${searchParams.toString()}`}
+          className="criteria-link"
+        >
           Find your landlord’s other buildings
         </JFCLLinkInternal>
       </>

--- a/src/hooks/useCriteriaResults.tsx
+++ b/src/hooks/useCriteriaResults.tsx
@@ -32,22 +32,24 @@ export type CriteriaDetails = {
 
 export function useCriteriaResults(
   formFields: FormFields,
+  searchParams: URLSearchParams,
   bldgData?: BuildingData
 ): CriteriaDetails | undefined {
   if (!bldgData) return undefined;
   const criteriaData: CriteriaData = { ...formFields, ...bldgData };
   return {
-    portfolioSize: eligibilityPortfolioSize(criteriaData),
+    portfolioSize: eligibilityPortfolioSize(criteriaData, searchParams),
     buildingClass: eligibilityBuildingClass(criteriaData),
     rent: eligibilityRent(criteriaData),
-    rentStabilized: eligibilityRentStabilized(criteriaData),
+    rentStabilized: eligibilityRentStabilized(criteriaData, searchParams),
     certificateOfOccupancy: eligibilityCertificateOfOccupancy(criteriaData),
     subsidy: eligibilitySubsidy(criteriaData),
   };
 }
 
 function eligibilityPortfolioSize(
-  criteriaData: CriteriaData
+  criteriaData: CriteriaData,
+  searchParams: URLSearchParams
 ): CriterionDetails {
   const { unitsres, related_properties, landlord, portfolioSize, bbl } =
     criteriaData;
@@ -101,7 +103,10 @@ function eligibilityPortfolioSize(
           {`Your building has only ${unitsres} apartments, but your landlord may own
           ${relatedProperties - 1} other buildings`}
           <br />
-          <JFCLLinkInternal to="/portfolio_size" className="criteria-link">
+          <JFCLLinkInternal
+            to={`/portfolio_size?${searchParams.toString()}`}
+            className="criteria-link"
+          >
             Find your landlord’s other buildings
           </JFCLLinkInternal>
         </>
@@ -165,7 +170,8 @@ function eligibilityRent(criteriaData: CriteriaData): CriterionDetails {
 }
 
 function eligibilityRentStabilized(
-  criteriaData: CriteriaData
+  criteriaData: CriteriaData,
+  searchParams: URLSearchParams
 ): CriterionDetails {
   const { rentStabilized } = criteriaData;
   const criteria = "rentStabilized";
@@ -188,7 +194,10 @@ function eligibilityRentStabilized(
       <>
         You reported that you are not sure if your apartment is rent stabilized.
         <br />
-        <JFCLLinkInternal to="/rent_stabilization" className="criteria-link">
+        <JFCLLinkInternal
+          to={`/rent_stabilization?${searchParams.toString()}`}
+          className="criteria-link"
+        >
           Find out if you are rent stabilized
         </JFCLLinkInternal>
       </>

--- a/src/hooks/useSearchParamsURL.ts
+++ b/src/hooks/useSearchParamsURL.ts
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+import { SetURLSearchParams } from "react-router-dom";
+import { GCEUser } from "../types/APIDataTypes";
+import { Address } from "../Components/Pages/Home/Home";
+import { FormFields } from "../Components/Pages/Form/Survey";
+
+export const useSearchParamsURL = (
+  setSearchParams: SetURLSearchParams,
+  address: Address,
+  fields: FormFields,
+  user?: GCEUser
+) => {
+  useEffect(() => {
+    // save session state in params
+    if (address && fields) {
+      setSearchParams(
+        {
+          ...(!!user?.id && { user: JSON.stringify(user.id) }),
+          address: JSON.stringify(address),
+          fields: JSON.stringify(fields),
+        },
+        { replace: true }
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+};


### PR DESCRIPTION
[next steps accordions default closed on all browser/device](https://github.com/JustFixNYC/gce-screener/commit/02d4da672c34f2c6e329722cb5b4dbbceca1d479)
- Joel confirmed that these should always be closed now (previously they were open by default on mobile

[progress bar fill number for all visited steps](https://github.com/JustFixNYC/gce-screener/commit/3a4ff6ddd189f16b2b83c82059a989392aa49805)
- previously only the current step number was filled in

[use `<nav>` for footer links, progress back, back-to-results](https://github.com/JustFixNYC/gce-screener/commit/deee94490458e5f363825724bd44b70b880b6209)
- this [a11y style guide](https://a11y-style-guide.com/style-guide/section-navigation.html) suggests using `<nav>` elements for these cases

[use custom hook for open/close accordions on print](https://github.com/JustFixNYC/gce-screener/commit/09e3523fa6d0df447f9a409df318f1438efdcecd)
- just to prevent repetition of the useeffect that sets up the listeners

[custom hook for url params, add to RS guide, rename eligibility hook,…](https://github.com/JustFixNYC/gce-screener/commit/3e2e87da7aa28d38052e6f5ae4674afc8ec424e7)
- creates a custom hook for the useEffect that sets the url search params since we use this in a few places
- add url search params for the rent stab guide page
- unrelated, but I also renamed the eligibility file for the useCriteriaDetails hook
- include the search params in links to the guide pages from the results page. This solves the issue we found when you open those links from results into a new tab it redirects to home since it was missing necessary session data.