### PR TITLE
add data source links to survey helper text, update subsidy copy

### DIFF
--- a/src/Components/Pages/Form/Survey.scss
+++ b/src/Components/Pages/Form/Survey.scss
@@ -22,6 +22,9 @@
     margin-bottom: 1.5rem; // 24px
     .info-box__content-container {
       @include body_standard_desktop;
+      .source-link {
+        @include small_text_desktop;
+      }
     }
   }
 

--- a/src/Components/Pages/Form/Survey.tsx
+++ b/src/Components/Pages/Form/Survey.tsx
@@ -27,7 +27,7 @@ export type FormFields = {
   rent: string | null;
   landlord: "YES" | "NO" | "UNSURE" | null;
   rentStabilized: "YES" | "NO" | "UNSURE" | null;
-  housingType: "NYCHA" | "SUBSIDIZED" | "NONE" | "UNSURE" | null;
+  housingType: "NYCHA" | "SUBSIDIZED" | "NONE" | null;
   portfolioSize?: "YES" | "NO" | "UNSURE" | null;
 };
 
@@ -273,9 +273,14 @@ export const Survey: React.FC = () => {
                     name: "housingType",
                     options: [
                       { label: "NYCHA or PACT/RAD", value: "NYCHA" },
-                      { label: "Subsidized housing", value: "SUBSIDIZED" },
-                      { label: "None of these", value: "NONE" },
-                      { label: "I'm not sure", value: "UNSURE" },
+                      { label: "Mitchell-Lama", value: "SUBSIDIZED" },
+                      { label: "LIHTC", value: "SUBSIDIZED" },
+                      { label: "HDFC", value: "SUBSIDIZED" },
+                      { label: "Other", value: "SUBSIDIZED" },
+                      {
+                        label: "No, my apartment is not subsidized",
+                        value: "NONE",
+                      },
                     ],
                   }}
                   onChange={handleRadioChange}

--- a/src/Components/Pages/Home/Home.tsx
+++ b/src/Components/Pages/Home/Home.tsx
@@ -76,7 +76,7 @@ export const Home: React.FC = () => {
       <Header
         title={
           <>
-            Learn if you're covered <br />
+            Learn if you’re covered <br />
             by Good Cause <br />
             Eviction law in NYC
           </>

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -49,6 +49,7 @@ export const urlZOLA = (bbl: string): string => {
 export const urlDOBBIN = (bin: string): string => {
   return `https://a810-bisweb.nyc.gov/bisweb/COsByLocationServlet?allbin=${bin}`;
 };
+
 export const urlDOBBBL = (bbl: string): string => {
   const { boro, block, lot } = splitBBL(bbl);
   return `https://a810-bisweb.nyc.gov/bisweb/PropertyProfileOverviewServlet?boro=${boro}&block=${block}&lot=${lot}`;
@@ -56,6 +57,10 @@ export const urlDOBBBL = (bbl: string): string => {
 
 export const urlFCSubsidized = (bbl: string): string => {
   return `https://app.coredata.nyc/?ptsb=${bbl}`;
+};
+
+export const urlWOWTimelineRS = (bbl: string): string => {
+  return `https://whoownswhat.justfix.org/bbl/${bbl}/timeline/rentstabilizedunits`;
 };
 
 export const abbreviateBoro = (borough: string): string => {

--- a/src/hooks/eligibility.tsx
+++ b/src/hooks/eligibility.tsx
@@ -2,7 +2,7 @@ import { FormFields } from "../Components/Pages/Form/Survey";
 import JFCLLinkInternal from "../Components/JFCLLinkInternal";
 import { BuildingData, CriterionResult } from "../types/APIDataTypes";
 import JFCLLinkExternal from "../Components/JFCLLinkExternal";
-import { urlDOBBBL, urlDOBBIN, urlFCSubsidized, urlZOLA } from "../helpers";
+import { urlDOBBBL, urlDOBBIN, urlZOLA } from "../helpers";
 
 export type Criteria =
   | "portfolioSize"
@@ -304,36 +304,13 @@ function eligibilityCertificateOfOccupancy(
 }
 
 function eligibilitySubsidy(criteriaData: CriteriaData): CriterionDetails {
-  const { housingType, is_nycha, is_subsidized, bbl } = criteriaData;
+  const { housingType } = criteriaData;
   const criteria = "subsidy";
   const requirement = "You must not live in subsidized or public housing.";
   let determination: CriterionResult;
   let userValue: React.ReactNode;
 
-  if (housingType == "UNSURE") {
-    determination = "UNKNOWN";
-    if (is_nycha || is_subsidized) {
-      userValue = (
-        <>
-          {"You reported that you are not sure if you live in subsidized or public housing, " +
-            `but available data indicates that your building is ${
-              is_nycha ? "NYCHA" : "subsidized"
-            }.`}
-          <br />
-          <JFCLLinkExternal
-            href={urlFCSubsidized(bbl)}
-            className="criteria-link"
-          >
-            View source
-          </JFCLLinkExternal>
-        </>
-      );
-    } else {
-      userValue =
-        "You reported that you are not sure if you live in NYCHA or subsidized housing, " +
-        "and there is no indication from public data that your building is public housing or subsidized.";
-    }
-  } else if (housingType === "NYCHA" || housingType === "SUBSIDIZED") {
+  if (housingType === "NYCHA" || housingType === "SUBSIDIZED") {
     determination = "INELIGIBLE";
     userValue = `You reported that you live in ${
       housingType === "NYCHA" ? "NYCHA" : "subsidized"


### PR DESCRIPTION
Adds a "view source" link for survey helper text boxes for  rent stabilized units and subsidy program. Subsidy (and 421a/J51) links to building page on FC's Core Data, and RS units links to a wow building page's timeline tab for the rent stab units indicator. The ability to make these bbl-based links to WOW building page tabs is added in https://github.com/JustFixNYC/who-owns-what/pull/986

I also adjust the language a bit in the subsidy helper text based on the program. And make some copy updates for the no-data case. 

[sc-16147]
[sc-15985]