### PR TITLE
use role=alert/status on error messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@contentful/rich-text-react-renderer": "^16.0.1",
-    "@justfixnyc/component-library": "0.54.1",
+    "@justfixnyc/component-library": "0.54.2",
     "@justfixnyc/geosearch-requester": "^1.0.3-alpha.0",
     "@rollbar/react": "^0.12.0-beta",
     "contentful": "^11.4.4",

--- a/src/Components/GeoSearchInput/GeoSearchInput.tsx
+++ b/src/Components/GeoSearchInput/GeoSearchInput.tsx
@@ -69,6 +69,7 @@ export const GeoSearchInput: React.FC<GeoSearchInputProps> = ({
         placeholder={!isFocused && placeholder}
         invalid={!isFocused && invalid}
         invalidText="You must enter an address"
+        invalidRole="alert"
         onFocus={() => {
           setInvalid(false);
           setIsFocused(true);

--- a/src/Components/InfoBox/InfoBox.tsx
+++ b/src/Components/InfoBox/InfoBox.tsx
@@ -6,16 +6,20 @@ import "./InfoBox.scss";
 type InfoBoxProps = {
   children: ReactNode;
   color?: "white" | "blue" | "orange";
+  role?: string;
 };
 
 export const InfoBox: React.FC<InfoBoxProps> = ({
   children,
   color = "white",
+  role,
 }) => (
   <div className={classNames("info-box", color)}>
     <div className="info-box__icon-container">
       <Icon icon="circleInfo" />
     </div>
-    <div className="info-box__content-container">{children}</div>
+    <div className="info-box__content-container" role={role}>
+      {children}
+    </div>
   </div>
 );

--- a/src/Components/Pages/Form/Survey.tsx
+++ b/src/Components/Pages/Form/Survey.tsx
@@ -127,7 +127,7 @@ export const Survey: React.FC = () => {
       <div className="content-section">
         <div className="content-section__content">
           {showErrors && (
-            <InfoBox color="orange">
+            <InfoBox color="orange" role="alert">
               Please complete the unanswered questions before continuing.
             </InfoBox>
           )}
@@ -142,6 +142,7 @@ export const Survey: React.FC = () => {
                 legendText="How many bedrooms are in your apartment?"
                 invalid={showErrors && localFields.bedrooms === null}
                 invalidText="Please select one"
+                invalidRole="status"
               >
                 <RadioGroup
                   fields={localFields}
@@ -176,6 +177,7 @@ export const Survey: React.FC = () => {
                 }
                 invalid={showErrors && localFields.rent === null}
                 invalidText="Enter your total rent amount"
+                invalidRole="status"
                 id="rent-input"
                 type="money"
                 name="rent"
@@ -205,6 +207,7 @@ export const Survey: React.FC = () => {
                 }
                 invalid={showErrors && localFields.rentStabilized === null}
                 invalidText="Please select one"
+                invalidRole="status"
               >
                 <RadioGroup
                   fields={localFields}
@@ -236,6 +239,7 @@ export const Survey: React.FC = () => {
                 }
                 invalid={showErrors && localFields.housingType === null}
                 invalidText="Please select one"
+                invalidRole="status"
               >
                 <RadioGroup
                   fields={localFields}
@@ -265,6 +269,7 @@ export const Survey: React.FC = () => {
                     legendText="Does your landlord live in the building?"
                     invalid={showErrors && localFields.landlord === null}
                     invalidText="Please select one"
+                    invalidRole="status"
                   >
                     <RadioGroup
                       fields={localFields}
@@ -297,6 +302,7 @@ export const Survey: React.FC = () => {
                     }
                     invalid={showErrors && localFields.portfolioSize === null}
                     invalidText="Please select one"
+                    invalidRole="status"
                   >
                     <RadioGroup
                       fields={localFields}

--- a/yarn.lock
+++ b/yarn.lock
@@ -477,10 +477,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@justfixnyc/component-library@0.54.1":
-  version "0.54.1"
-  resolved "https://registry.yarnpkg.com/@justfixnyc/component-library/-/component-library-0.54.1.tgz#8ae5e5c6a08507f96959c476a73fa3526dcb4f44"
-  integrity sha512-NUTROBML/qrxNdaMQvrjJlt4yJPJUWJzsX89WM4oG5sCYKTZUgkKRQvI4K96UR6fSuYn/9KMlVtFUoAS0fTp+A==
+"@justfixnyc/component-library@0.54.2":
+  version "0.54.2"
+  resolved "https://registry.yarnpkg.com/@justfixnyc/component-library/-/component-library-0.54.2.tgz#66c413208f211cccf1f0c65727dd93d901c803a3"
+  integrity sha512-7egUNCT8AFSbYXGUhOkqDU32xeIOou4861BmIpw7lGVbvuVyBI49uGIyKdUGGLm/bdVyOpY5/m/+FNFxZUA6ew==
   dependencies:
     "@awesome.me/kit-dd32553919" "^1.0.13"
     "@babel/runtime" "^7.12.5"


### PR DESCRIPTION
Use `role="alert"` on the error messages for address search bar and the overall incomplete survey, and `role="status"` for each individual survey question. This makes it so that the alert errors are announced by screen readers immediately, and on the survey page it then lists each specific questions error message afterwards (waiting on copy updates from Corey to make them more clear, but can update that later)

[sc-16149]