### PR TITLE
add github action to scan for deadlinks

### DIFF
--- a/.github/workflows/deadlink.yml
+++ b/.github/workflows/deadlink.yml
@@ -1,0 +1,15 @@
+on:
+  schedule:
+  - cron: "0 5 1 * *"
+  workflow_dispatch:
+
+jobs:
+  find_dead_links:
+    runs-on: ubuntu-latest
+    name: Deadlink crawler
+    steps:
+      - name: Scan Good Cause NYC Dead Links
+        uses: JustFixNYC/deadlink-crawler@v2.1
+        with:
+          site-url: "http://goodcausenyc.org"
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
adds our github action that checks for dead links. 

I continued to have problems with good links being marked as broken, and after looking more into it is seemed like other people were having problems as well and the project haven't been updated in many years now. So I switched over to a different package for the link scanning and updated the repo and tested it out on the orgsite, and it seems to be working better. 

https://github.com/JustFixNYC/deadlink-crawler
https://github.com/JustFixNYC/justfix-website/issues/396

I adjusted the formatting of the GH issue to show it two ways - one like it was with each page and the broken links on that page, and an alternative format with each unique broken url and all the pages it appears on (this is helpful when it's something like the generic rent stab fact sheets that is linked across many LC articles)