### PR TITLE
Covered page updates (rent increase, reorder protections) 

### DIFF
--- a/src/Components/ContentBox/ContentBox.scss
+++ b/src/Components/ContentBox/ContentBox.scss
@@ -16,6 +16,30 @@ $videoEmbedW: 623px;
   @include for-phone-only() {
     margin: unset;
   }
+
+  #gce-protections_rent {
+    strong {
+      display: inline-block;
+      margin-bottom: 0.5rem;
+    }
+
+    .rent-increase {
+      display: block;
+      margin: 1rem 0;
+      .amount {
+        @include body_large_desktop;
+        &.bold {
+          font-weight: 600;
+        }
+      }
+      .formula {
+        &.bold {
+          @include body_large_desktop;
+          font-weight: 600;
+        }
+      }
+    }
+  }
 }
 
 .content-box__header {
@@ -71,6 +95,17 @@ $videoEmbedW: 623px;
       iframe {
         border: 0px;
       }
+    }
+
+    .callout-box {
+      display: flex;
+      flex-direction: row;
+      gap: 1rem;
+      padding: 1rem;
+      background-color: #efe9dc;
+      border-radius: 4px;
+      margin-bottom: 1.5rem;
+      max-width: $contentPWidth;
     }
 
     .note-box {

--- a/src/Components/ContentBox/ContentBox.scss
+++ b/src/Components/ContentBox/ContentBox.scss
@@ -38,6 +38,11 @@ $videoEmbedW: 623px;
           font-weight: 600;
         }
       }
+      @include for-tablet-portrait-up {
+        br {
+          display: none;
+        }
+      }
     }
   }
 }

--- a/src/Components/KYRContent/KYRContent.tsx
+++ b/src/Components/KYRContent/KYRContent.tsx
@@ -7,6 +7,7 @@ import {
 import JFCLLinkExternal from "../JFCLLinkExternal";
 import { formatMoney } from "../../helpers";
 import { CoverageResult } from "../../types/APIDataTypes";
+import classNames from "classnames";
 
 const CPI = 3.82;
 
@@ -177,6 +178,52 @@ export const GoodCauseProtections: React.FC<
     <>
       <ContentBox title={title} subtitle={subtitle}>
         <ContentBoxItem
+          title="Your right to limited rent increases"
+          gtmId="gce-protections_rent"
+          coverageResult={coverageResult}
+        >
+          <p>
+            {`The state housing agency must publish each year’s Reasonable Rent
+          Increase by August. This year the maximum amount your landlord can
+          increase your rent by is ${increase_pct}%.`}
+          </p>
+          <br />
+          <div className="callout-box">
+            <p>
+              If you are offered a new lease after April 20th, 2024 with an
+              amount higher than:
+              <span className="rent-increase">
+                {!!rent && (
+                  <span className="amount bold">
+                    {`${formatMoney(rent * (1 + increase_pct / 100))}`}{" "}
+                  </span>
+                )}
+                <span className={classNames("formula", !rent && "bold")}>
+                  {!!rent
+                    ? `(${formatMoney(rent)} + ${increase_pct}%)`
+                    : `your current rent + ${increase_pct}%`}
+                </span>
+              </span>
+              you should ask your landlord to provide reasons for the increase
+              beyond the {`${increase_pct}%`} reasonable rent standard.
+            </p>
+          </div>
+          <p>
+            <strong>Note</strong>
+            <br />
+            Landlords can increase the rent more than the reasonable rent
+            increase but they must explain why and must point to increases in
+            their costs or substantial repairs they did to the apartment or
+            building.
+          </p>
+          <JFCLLinkExternal
+            className="has-label"
+            to="https://legalaidnyc.org/get-help/housing-problems/what-you-need-to-know-about-new-yorks-good-cause-eviction-law/#rent-increases"
+          >
+            Learn more about Reasonable Rent Increase
+          </JFCLLinkExternal>
+        </ContentBoxItem>
+        <ContentBoxItem
           title="Your right to stay in your home"
           gtmId="gce-protections_eviction"
           coverageResult={coverageResult}
@@ -188,52 +235,6 @@ export const GoodCauseProtections: React.FC<
           </p>
         </ContentBoxItem>
 
-        <ContentBoxItem
-          title="Your right to limited rent increases"
-          gtmId="gce-protections_rent"
-          coverageResult={coverageResult}
-        >
-          <p>
-            {`The state housing agency must publish each year’s Reasonable Rent
-          Increase by August. This year the maximum amount your landlord can
-          increase your rent by is ${increase_pct}%.`}
-          </p>
-          <br />
-
-          <p>
-            {rent
-              ? `If you are offered a new lease after April 20th, 2024 with an 
-              amount higher than ${formatMoney(
-                rent * (1 + increase_pct / 100)
-              )} (your current rent + ${increase_pct}%) you should ask your
-              landlord to provide reasons for the increase beyond the ${increase_pct}% 
-              reasonable rent standard.`
-              : `If you are offered a new lease after April 20th, 2024 with an amount 
-              higher than your current rent + ${increase_pct}%, you should ask your 
-              landlord to provide reasons for the increase beyond the ${increase_pct}% 
-              reasonable rent standard.`}
-          </p>
-          <div className="note-box">
-            <p>
-              <strong>Note</strong>
-            </p>
-            <p>
-              Landlords can increase the rent more than the reasonable rent
-              increase but they must explain why and must point to increases in
-              their costs or substantial repairs they did to the apartment or
-              building.
-            </p>
-          </div>
-          <p>
-            <strong>Learn about Reasonable Rent Standard</strong>
-          </p>
-          <JFCLLinkExternal
-            className="has-label"
-            to="https://legalaidnyc.org/get-help/housing-problems/what-you-need-to-know-about-new-yorks-good-cause-eviction-law/#rent-increases"
-          >
-            Reasonable Rent Increase
-          </JFCLLinkExternal>
-        </ContentBoxItem>
         <ContentBoxItem
           title="Learn more about Good Cause Eviction Law protections"
           gtmId="gce-protections_learn"

--- a/src/Components/KYRContent/KYRContent.tsx
+++ b/src/Components/KYRContent/KYRContent.tsx
@@ -198,6 +198,7 @@ export const GoodCauseProtections: React.FC<
                     {`${formatMoney(rent * (1 + increase_pct / 100))}`}{" "}
                   </span>
                 )}
+                <br />
                 <span className={classNames("formula", !rent && "bold")}>
                   {!!rent
                     ? `(${formatMoney(rent)} + ${increase_pct}%)`

--- a/src/Components/Pages/Results/Results.scss
+++ b/src/Components/Pages/Results/Results.scss
@@ -332,7 +332,7 @@
       margin-left: calc(var(--icon-size) + var(--icon-margin));
     }
   }
-  .callout-box {
+  .phone-number-callout-box {
     display: flex;
     flex-direction: row;
     gap: 1.5rem; // 24px

--- a/src/Components/Pages/Results/Results.tsx
+++ b/src/Components/Pages/Results/Results.tsx
@@ -153,6 +153,7 @@ export const Results: React.FC = () => {
           )}
           {coverageResult === "COVERED" && (
             <>
+              <GoodCauseProtections rent={Number(fields.rent)} />
               <GoodCauseExercisingRights
                 coverageResult={coverageResult}
                 shareButtons={
@@ -167,7 +168,6 @@ export const Results: React.FC = () => {
                   />
                 }
               />
-              <GoodCauseProtections rent={Number(fields.rent)} />
             </>
           )}
           {coverageResult === "NYCHA" && (
@@ -522,7 +522,7 @@ const PhoneNumberCallout: React.FC<{ coverageResult?: CoverageResult }> = ({
   };
 
   return (
-    <div className="callout-box">
+    <div className="phone-number-callout-box">
       <div className="callout-box__column">
         <span className="callout-box__header">
           Help build tenant power in NYC


### PR DESCRIPTION
on the results page: 
<img width="841" alt="Screenshot 2025-02-18 at 12 49 37 AM" src="https://github.com/user-attachments/assets/b957a163-b99e-4c48-9f84-39bf33f335ae" />

on KYR page: 
<img width="835" alt="Screenshot 2025-02-18 at 12 50 04 AM" src="https://github.com/user-attachments/assets/09d8d894-5b27-4456-b798-fe04b6f54b9e" />
