### PR TITLE
show/hide header on scroll

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -18,15 +18,10 @@
 #container {
   display: flex;
   flex-direction: column;
-  height: 100%;
 }
 
 #main {
   flex-grow: 1;
-  margin-top: $headerH;
-  @media print {
-    margin-top: 0;
-  }
 
   #content {
     height: 100%;

--- a/src/Components/TopBar/TopBar.scss
+++ b/src/Components/TopBar/TopBar.scss
@@ -14,6 +14,10 @@
   text-wrap: nowrap;
   z-index: 100;
 
+  &.scrolling-up {
+    display: none;
+  }
+
   div {
     height: $headerH - (1.5rem * 2);
   }

--- a/src/Components/TopBar/TopBar.scss
+++ b/src/Components/TopBar/TopBar.scss
@@ -2,8 +2,16 @@
 @import "../../variables.scss";
 @import "../../mixins.scss";
 
+$headerH: 4.5rem; // H1 line-height (1.5rem) + vertical padding (1.5rem x 2)
+
+#topbar-placeholder {
+  height: $headerH;
+  &.hide {
+    position: absolute;
+  }
+}
 #topbar {
-  position: fixed;
+  position: sticky;
   top: 0;
   background-color: $OFF_WHITE_200;
   border-bottom: 1px solid $OFF_BLACK;
@@ -14,7 +22,7 @@
   text-wrap: nowrap;
   z-index: 100;
 
-  &.scrolling-up {
+  &.hide {
     display: none;
   }
 

--- a/src/Components/TopBar/TopBar.tsx
+++ b/src/Components/TopBar/TopBar.tsx
@@ -1,42 +1,54 @@
+import { useRef } from "react";
 import { Link } from "react-router-dom";
-import "./TopBar.scss";
+import classNames from "classnames";
 import { gtmPush } from "../../google-tag-manager";
 import { useScrollDirection } from "../../hooks/useScrollDirection";
-import classNames from "classnames";
+import useInViewPort from "../../hooks/useInViewport";
+import "./TopBar.scss";
 
 export const TopBar: React.FC = () => {
   const isScrollingUp = useScrollDirection() === "up";
+  const placeholderRef = useRef<HTMLDivElement | null>(null);
+  const placeholderInViewport = useInViewPort(placeholderRef);
+  const hideTopbar = !(isScrollingUp || placeholderInViewport);
 
   return (
-    <header id="topbar" className={classNames(isScrollingUp && "scrolling-up")}>
-      <div className="topbar__name">
-        <h1>
-          <Link to="/">Good Cause NYC</Link>
-        </h1>
-      </div>
-      <div className="topbar__collab">
-        <span>By</span>{" "}
-        <a
-          href="https://housingjusticeforall.org/"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Housing Justice for All
-        </a>{" "}
-        <span>&</span>{" "}
-        <a
-          href="https://justfix.org/"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          JustFix
-        </a>
-      </div>
-      <div className="topbar__search">
-        <Link to="/" onClick={() => gtmPush("gce_new_search")}>
-          New Search
-        </Link>
-      </div>
-    </header>
+    <>
+      <header id="topbar" className={classNames(hideTopbar && "hide")}>
+        <div className="topbar__name">
+          <h1>
+            <Link to="/">Good Cause NYC</Link>
+          </h1>
+        </div>
+        <div className="topbar__collab">
+          <span>By</span>{" "}
+          <a
+            href="https://housingjusticeforall.org/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Housing Justice for All
+          </a>{" "}
+          <span>&</span>{" "}
+          <a
+            href="https://justfix.org/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            JustFix
+          </a>
+        </div>
+        <div className="topbar__search">
+          <Link to="/" onClick={() => gtmPush("gce_new_search")}>
+            New Search
+          </Link>
+        </div>
+      </header>
+      <div
+        ref={placeholderRef}
+        id="topbar-placeholder"
+        className={classNames(!hideTopbar && "hide")}
+      />
+    </>
   );
 };

--- a/src/Components/TopBar/TopBar.tsx
+++ b/src/Components/TopBar/TopBar.tsx
@@ -1,10 +1,14 @@
 import { Link } from "react-router-dom";
 import "./TopBar.scss";
 import { gtmPush } from "../../google-tag-manager";
+import { useScrollDirection } from "../../hooks/useScrollDirection";
+import classNames from "classnames";
 
 export const TopBar: React.FC = () => {
+  const isScrollingUp = useScrollDirection() === "up";
+
   return (
-    <header id="topbar">
+    <header id="topbar" className={classNames(isScrollingUp && "scrolling-up")}>
       <div className="topbar__name">
         <h1>
           <Link to="/">Good Cause NYC</Link>

--- a/src/hooks/useInViewport.tsx
+++ b/src/hooks/useInViewport.tsx
@@ -1,0 +1,26 @@
+import { useState, useEffect } from "react";
+
+// https://medium.com/@serifcolakel/utilizing-intersection-observer-with-custom-react-hook-in-typescript-5a27575ee154
+
+function useInViewPort<T extends HTMLElement>(
+  ref: React.RefObject<T>,
+  options?: IntersectionObserverInit
+) {
+  const [inViewport, setInViewport] = useState(false);
+  useEffect(() => {
+    const observer = new IntersectionObserver(([entry]) => {
+      setInViewport(entry.isIntersecting);
+    }, options);
+    const currentRef = ref.current;
+    if (currentRef) {
+      observer.observe(currentRef);
+    }
+    return () => {
+      if (currentRef) {
+        observer.unobserve(currentRef);
+      }
+    };
+  }, [options, ref]);
+  return inViewport;
+}
+export default useInViewPort;

--- a/src/hooks/useScrollDirection.ts
+++ b/src/hooks/useScrollDirection.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+
+/** Hook to get scroll direction for sticky header */
+// https://stackoverflow.com/a/62497293/7051239
+export const useScrollDirection = (): "up" | "down" => {
+  const [scrollDir, setScrollDir] = useState<"up" | "down">("down");
+
+  useEffect(() => {
+    const threshold = 0;
+    let lastScrollY = window.pageYOffset;
+    let ticking = false;
+
+    const updateScrollDir = () => {
+      const scrollY = window.pageYOffset;
+
+      if (Math.abs(scrollY - lastScrollY) < threshold) {
+        ticking = false;
+        return;
+      }
+      setScrollDir(scrollY > lastScrollY ? "down" : "up");
+      lastScrollY = scrollY > 0 ? scrollY : 0;
+      ticking = false;
+    };
+
+    const onScroll = () => {
+      if (!ticking) {
+        window.requestAnimationFrame(updateScrollDir);
+        ticking = true;
+      }
+    };
+
+    window.addEventListener("scroll", onScroll);
+
+    return () => window.removeEventListener("scroll", onScroll);
+  }, [scrollDir]);
+
+  return scrollDir;
+};

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -1,3 +1,2 @@
-$headerH: 4.5rem; // H1 line-height (1.5rem) + vertical padding (1.5rem x 2)
 $contentBoxPadding: 2rem;
 $contentBoxWidth: calc(886px - (2 * $contentBoxPadding));


### PR DESCRIPTION
When scrolling down the topbar should hide, and show on scroll up. 

Adds two hooks - to detect scroll direction, and detect if element is in the viewport. The header gets position sticky, and a placeholder div remains at the top to keep the space. when scrolling down the sticky header dissapears, and reappears when scrolling up. When you get to the top and the invisible placeholder is visible, the sticky header always shows.

This setup seems to work ok, but the downside is that the hiding of the sticky header is done with `display:none` and so can't be transitioned to slide away. I briefly tried to just shift the sticky header off screen using `top: -100px`, but then it would glitch out at the top of the page