### PR TITLE
add landlord criterion to results and headline logic

### DIFF
--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -97,5 +97,6 @@ export const getCriteriaResults = (
     c_of_o: criteriaDetails?.certificateOfOccupancy?.determination,
     subsidy: criteriaDetails?.subsidy?.determination,
     portfolio_size: criteriaDetails?.portfolioSize?.determination,
+    landlord: criteriaDetails?.landlord?.determination,
   };
 };

--- a/src/types/APIDataTypes.ts
+++ b/src/types/APIDataTypes.ts
@@ -65,6 +65,7 @@ export type CriteriaResults = {
   c_of_o?: CriterionResult;
   subsidy?: CriterionResult;
   portfolio_size?: CriterionResult;
+  landlord?: CriterionResult;
 };
 
 export type FormAnswers = {


### PR DESCRIPTION
The live-in landlord variable was left out of the data for compiling the results of each criterion so it was not being considered in the headline logic - this fixes that. 