### PR TITLE
remove old -1 on related properties count criteria table

### DIFF
--- a/src/hooks/useCriteriaResults.tsx
+++ b/src/hooks/useCriteriaResults.tsx
@@ -63,7 +63,7 @@ function eligibilityPortfolioSize(
   searchParams: URLSearchParams
 ): CriterionDetails {
   const { unitsres, related_properties, portfolioSize } = criteriaData;
-  const relatedProperties = related_properties.length - 1 || 0;
+  const relatedProperties = related_properties.length || 0;
 
   const criteria = "portfolioSize";
   const requirement =


### PR DESCRIPTION
In an early version of the data the property itself was getting included in the related list, but that's now fixed so need to remove the `-1` when showing the count of related properties