### PR TITLE
add missing portfolio size field in survey data for backend

### DIFF
--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -74,6 +74,7 @@ export const cleanFormFields = ({
   landlord,
   rentStabilized,
   housingType,
+  portfolioSize,
 }: FormFields): FormAnswers => {
   return {
     bedrooms: bedrooms || undefined,
@@ -83,6 +84,7 @@ export const cleanFormFields = ({
     subsidy: housingType?.includes("SUBSIDIZED")
       ? "SUBSIDIZED"
       : housingType || undefined,
+    portfolio_size: portfolioSize || undefined,
   };
 };
 

--- a/src/types/APIDataTypes.ts
+++ b/src/types/APIDataTypes.ts
@@ -74,6 +74,7 @@ export type FormAnswers = {
   owner_occupied?: string;
   rent_stab?: string;
   subsidy?: string;
+  portfolio_size?: string;
 };
 
 export type GCEPostData = {


### PR DESCRIPTION
Somehow the portfolio size field from the survey was left out of what we send to the tenants2 backend