### PR TITLE
fix padding on confirm address box desktop

### DIFF
--- a/src/Components/Pages/ConfirmAddress/ConfirmAddress.scss
+++ b/src/Components/Pages/ConfirmAddress/ConfirmAddress.scss
@@ -93,8 +93,10 @@ $mapImgHeight: 285px;
         flex-direction: column;
         justify-content: center;
         gap: 0.5rem; // 8px
+        margin-right: 2.25rem;
         @include for-phone-only() {
           gap: 0.25rem; // 4px
+          margin-right: 0;
         }
 
         .your-address {


### PR DESCRIPTION
Fix lack of padding for confirm address box
before:
![image](https://github.com/user-attachments/assets/a1ea6695-ffbe-4df0-8b08-9dfa5b985aaf)
