### PR TITLE
fix layout direction for mobile criteria table callout box

### DIFF
--- a/src/Components/Pages/Results/Results.scss
+++ b/src/Components/Pages/Results/Results.scss
@@ -162,8 +162,9 @@
         .accordion__content {
           padding: 0 0 1rem 3rem;
           .callout-box {
+            flex-direction: column;
             padding: 0.75rem;
-            gap: 0.75rem;
+            gap: unset;
             background: $OFF_WHITE_100;
             margin-bottom: 0;
             &,


### PR DESCRIPTION
before
![image](https://github.com/user-attachments/assets/a9edaf7c-7969-498b-a973-650064bf4609)


after
![image](https://github.com/user-attachments/assets/6e276b5c-7804-4860-9bed-af548bc39690)
