### PR TITLE
fix formatting of STATEN_ISLAND in data for tenants2

### DIFF
--- a/src/Components/Pages/Home/Home.tsx
+++ b/src/Components/Pages/Home/Home.tsx
@@ -9,7 +9,7 @@ import { FormFields } from "../Form/Survey";
 import { useSendGceData } from "../../../api/hooks";
 import { GCEPostData, GCEUser } from "../../../types/APIDataTypes";
 import { Header } from "../../Header/Header";
-import { ProgressStep } from "../../../helpers";
+import { ProgressStep, toMacroCase } from "../../../helpers";
 import { JFCLLinkExternal, JFCLLinkInternal } from "../../JFCLLink";
 import "./Home.scss";
 
@@ -53,11 +53,11 @@ export const Home: React.FC = () => {
       bbl: geoAddress.bbl,
       house_number: geoAddress.houseNumber,
       street_name: geoAddress.streetName,
-      borough: geoAddress.borough,
+      borough: toMacroCase(geoAddress.borough),
       zipcode: geoAddress.zipcode,
     };
 
-    if (import.meta.env.MODE === "production") {
+    if (import.meta.env.MODE === "development") {
       try {
         const userResp = (await trigger(postData)) as GCEUser;
         setUser(userResp);

--- a/src/Components/Pages/Home/Home.tsx
+++ b/src/Components/Pages/Home/Home.tsx
@@ -57,7 +57,7 @@ export const Home: React.FC = () => {
       zipcode: geoAddress.zipcode,
     };
 
-    if (import.meta.env.MODE === "development") {
+    if (import.meta.env.MODE === "production") {
       try {
         const userResp = (await trigger(postData)) as GCEUser;
         setUser(userResp);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -16,6 +16,10 @@ export function toTitleCase(x: string) {
   );
 }
 
+export function toMacroCase(x: string) {
+  return x.replace(/\s+/g, "_").toUpperCase();
+}
+
 export const formatGeosearchAddress = (
   properties: GeoSearchProperties | undefined
 ): string =>


### PR DESCRIPTION
On the tenants2 DB we use the existing standard for borough names, which has `STATEN_ISLAND`, but from gce we were sending `STATEN ISLAND` so those records weren't getting saved. This just fixes that formatting. 

[sc-16249]