### PR TITLE
wait to send results to backend until ready

### DIFF
--- a/src/Components/Pages/Results/Results.tsx
+++ b/src/Components/Pages/Results/Results.tsx
@@ -72,24 +72,21 @@ export const Results: React.FC = () => {
   useAccordionsOpenForPrint();
   useSearchParamsURL(setSearchParams, address, fields, user);
 
+  const resultDataReady = !!coverageResult && !!criteriaResults?.building_class;
   useEffect(() => {
-    if (coverageResult && criteriaResults) {
-      if (import.meta.env.MODE === "production") {
-        try {
-          trigger({
-            id: user?.id,
-            result_coverage: coverageResult,
-            result_criteria: criteriaResults,
-          });
-        } catch {
-          rollbar.error("Cannot connect to tenant platform");
-        }
-      }
+    if (!resultDataReady) return;
+    if (import.meta.env.MODE !== "production") return;
+    try {
+      trigger({
+        id: user?.id,
+        result_coverage: coverageResult,
+        result_criteria: criteriaResults,
+      });
+    } catch {
+      rollbar.error("Cannot connect to tenant platform");
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  console.log(address);
+  }, [resultDataReady]);
 
   return (
     <div id="results-page">


### PR DESCRIPTION
We got some errors from the tenants2 backend where the result criteria values were missing. It looks like this happens if you go directly to a result page url and it needs to fetch the building data first but the useEffect was sending before it was ready. 

this PR makes two fixes for this. One is that the check for values we did before was incomplete - since the object will be there but the internal fields are all undefined. Then I just made this check a variable and added it to the dependencies for the useEffect so that if at first the data isn't ready and it skips the POST it will retry once the dataReady variable becomes true

[sc-16249]