### PR TITLE
remove prod condition for TP connection, send all data with results

### DIFF
--- a/src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx
+++ b/src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx
@@ -44,16 +44,14 @@ export const ConfirmAddress: React.FC = () => {
   const mapImageURL = `https://api.mapbox.com/styles/v1/${styleToken}/static/${marker}/${longLat},${zoom},${bearing},${pitch}/${width}x${height}?access_token=${accessToken}`;
 
   const handleSubmit = async () => {
-    if (import.meta.env.MODE === "production") {
-      try {
-        trigger({
-          id: user?.id,
-          address_confirmed: true,
-          nycdb_results: bldgData,
-        });
-      } catch {
-        rollbar.error("Cannot connect to tenant platform");
-      }
+    try {
+      trigger({
+        id: user?.id,
+        address_confirmed: true,
+        nycdb_results: bldgData,
+      });
+    } catch {
+      rollbar.error("Cannot connect to tenant platform");
     }
     navigate("/survey");
   };

--- a/src/Components/Pages/Form/Survey.tsx
+++ b/src/Components/Pages/Form/Survey.tsx
@@ -102,12 +102,10 @@ export const Survey: React.FC = () => {
       return;
     }
     setFields(localFields);
-    if (import.meta.env.MODE === "production") {
-      try {
-        trigger({ id: user?.id, form_answers: cleanFormFields(localFields) });
-      } catch {
-        rollbar.error("Cannot connect to tenant platform");
-      }
+    try {
+      trigger({ id: user?.id, form_answers: cleanFormFields(localFields) });
+    } catch {
+      rollbar.error("Cannot connect to tenant platform");
     }
     navigate(`/results`);
   };

--- a/src/Components/Pages/Home/Home.tsx
+++ b/src/Components/Pages/Home/Home.tsx
@@ -57,13 +57,11 @@ export const Home: React.FC = () => {
       zipcode: geoAddress.zipcode,
     };
 
-    if (import.meta.env.MODE === "production") {
-      try {
-        const userResp = (await trigger(postData)) as GCEUser;
-        setUser(userResp);
-      } catch {
-        rollbar.critical("Cannot connect to tenant platform");
-      }
+    try {
+      const userResp = (await trigger(postData)) as GCEUser;
+      setUser(userResp);
+    } catch {
+      rollbar.critical("Cannot connect to tenant platform");
     }
 
     removeFormFields();

--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -1,4 +1,5 @@
 import { FormFields } from "../Components/Pages/Form/Survey";
+import { Address } from "../Components/Pages/Home/Home";
 import { CriteriaDetails } from "../hooks/useCriteriaResults";
 import {
   CriteriaResults,
@@ -85,6 +86,16 @@ export const cleanFormFields = ({
       ? "SUBSIDIZED"
       : housingType || undefined,
     portfolio_size: portfolioSize || undefined,
+  };
+};
+
+export const cleanAddressFields = (address: Address) => {
+  return {
+    bbl: address.bbl,
+    house_number: address.houseNumber,
+    street_name: address.streetName,
+    borough: address.borough,
+    zipcode: address.zipcode,
   };
 };
 


### PR DESCRIPTION
We were having a problem when someone uses a results page link without a user id in the search params, we are only sending the results info to the tenant platform backend but we'll need to create a new record and are missing required fields (address fields). So we need to send all the data along with the results, and then also update the user in session storagewith the ID if there wasn't one set already. 

I also removed a condition we had left over from early on that only sent data to the backend on production, but there's no need for that, since we also just catch any errors so when you're working locally on front-end only things you still don't need to be runnings a local tenants2 server. 

There is also a companion PR on tenants2: https://github.com/JustFixNYC/tenants2/pull/2477