### PR TITLE
wrap inputs for enter-key submit on address, calculator, phone

### DIFF
--- a/src/Components/GeoSearchInput/GeoSearchInput.tsx
+++ b/src/Components/GeoSearchInput/GeoSearchInput.tsx
@@ -66,6 +66,7 @@ export const GeoSearchInput: React.FC<GeoSearchInputProps> = ({
           "is-highlighted": isHighlighted,
         })}
         options={options}
+        aria-label={placeholder}
         placeholder={!isFocused && placeholder}
         invalid={!isFocused && invalid}
         invalidText="You must enter an address"

--- a/src/Components/Pages/Home/Home.tsx
+++ b/src/Components/Pages/Home/Home.tsx
@@ -84,7 +84,11 @@ export const Home: React.FC = () => {
         }
         lastStepReached={lastStepReached}
       >
-        <form className="geo-search-form" onSubmit={handleAddressSearch}>
+        <form
+          className="geo-search-form"
+          onSubmit={handleAddressSearch}
+          aria-label="Enter your address"
+        >
           <GeoSearchInput
             initialAddress={address}
             onChange={setGeoAddress}

--- a/src/Components/Pages/Home/Home.tsx
+++ b/src/Components/Pages/Home/Home.tsx
@@ -44,7 +44,8 @@ export const Home: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const handleAddressSearch = async () => {
+  const handleAddressSearch = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
     if (!geoAddress) {
       setInputInvalid(true);
       return;
@@ -83,15 +84,15 @@ export const Home: React.FC = () => {
         }
         lastStepReached={lastStepReached}
       >
-        <div className="geo-search-form">
+        <form className="geo-search-form" onSubmit={handleAddressSearch}>
           <GeoSearchInput
             initialAddress={address}
             onChange={setGeoAddress}
             invalid={inputInvalid}
             setInvalid={setInputInvalid}
           />
-          <Button labelText="Get started" onClick={handleAddressSearch} />
-        </div>
+          <Button type="submit" labelText="Get started" />
+        </form>
       </Header>
 
       <div className="content-section home__about-law">

--- a/src/Components/Pages/Home/Home.tsx
+++ b/src/Components/Pages/Home/Home.tsx
@@ -84,11 +84,7 @@ export const Home: React.FC = () => {
         }
         lastStepReached={lastStepReached}
       >
-        <form
-          className="geo-search-form"
-          onSubmit={handleAddressSearch}
-          aria-label="Enter your address"
-        >
+        <form className="geo-search-form" onSubmit={handleAddressSearch}>
           <GeoSearchInput
             initialAddress={address}
             onChange={setGeoAddress}

--- a/src/Components/Pages/RentCalculator/RentCalculator.tsx
+++ b/src/Components/Pages/RentCalculator/RentCalculator.tsx
@@ -30,7 +30,8 @@ export const RentCalculator: React.FC = () => {
     setRentInput(value);
   };
 
-  const handleSubmit = () => {
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
     setShowRentInput(true);
     gtmPush("gce_rent_calculator_submit");
   };
@@ -49,7 +50,7 @@ export const RentCalculator: React.FC = () => {
             <span className="callout-box__header">
               Find out how much your landlord can increase your rent
             </span>
-            <div className="rent-input-container">
+            <form className="rent-input-container" onSubmit={handleSubmit}>
               <TextInput
                 labelText="Enter the total monthly rent for your entire apartment"
                 type="money"
@@ -68,9 +69,8 @@ export const RentCalculator: React.FC = () => {
                 variant="primary"
                 size="small"
                 labelText="Calculate"
-                onClick={handleSubmit}
               />
-            </div>
+            </form>
             <div className="rent-increase-container">
               <p className="rent-increase-header">
                 Allowable rent increase amount:

--- a/src/Components/Pages/RentCalculator/RentCalculator.tsx
+++ b/src/Components/Pages/RentCalculator/RentCalculator.tsx
@@ -50,7 +50,11 @@ export const RentCalculator: React.FC = () => {
             <span className="callout-box__header">
               Find out how much your landlord can increase your rent
             </span>
-            <form className="rent-input-container" onSubmit={handleSubmit}>
+            <form
+              className="rent-input-container"
+              onSubmit={handleSubmit}
+              aria-label="Enter the total monthly rent for your entire apartment"
+            >
               <TextInput
                 labelText="Enter the total monthly rent for your entire apartment"
                 type="money"

--- a/src/Components/Pages/RentCalculator/RentCalculator.tsx
+++ b/src/Components/Pages/RentCalculator/RentCalculator.tsx
@@ -50,11 +50,7 @@ export const RentCalculator: React.FC = () => {
             <span className="callout-box__header">
               Find out how much your landlord can increase your rent
             </span>
-            <form
-              className="rent-input-container"
-              onSubmit={handleSubmit}
-              aria-label="Enter the total monthly rent for your entire apartment"
-            >
+            <form className="rent-input-container" onSubmit={handleSubmit}>
               <TextInput
                 labelText="Enter the total monthly rent for your entire apartment"
                 type="money"

--- a/src/Components/Pages/Results/Results.tsx
+++ b/src/Components/Pages/Results/Results.tsx
@@ -597,7 +597,11 @@ export const PhoneNumberCallout: React.FC<{
           We’ll use your answers to better advocate for your rights.
         </p>
       </div>
-      <form className="callout-box__column" onSubmit={handleSubmit}>
+      <form
+        className="callout-box__column"
+        onSubmit={handleSubmit}
+        aria-label="Phone number"
+      >
         <div className="phone-number-input-container">
           <TextInput
             labelText="Phone number"

--- a/src/Components/Pages/Results/Results.tsx
+++ b/src/Components/Pages/Results/Results.tsx
@@ -557,7 +557,8 @@ export const PhoneNumberCallout: React.FC<{
     setShowError(false);
   };
 
-  const handleSubmit = () => {
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
     const cleaned = phoneNumber.replace(/\D/g, "");
     if (cleaned.length === VALID_PHONE_NUMBER_LENGTH) {
       try {
@@ -596,7 +597,7 @@ export const PhoneNumberCallout: React.FC<{
           We’ll use your answers to better advocate for your rights.
         </p>
       </div>
-      <div className="callout-box__column">
+      <form className="callout-box__column" onSubmit={handleSubmit}>
         <div className="phone-number-input-container">
           <TextInput
             labelText="Phone number"
@@ -613,7 +614,6 @@ export const PhoneNumberCallout: React.FC<{
             labelText="Submit"
             variant="secondary"
             size="small"
-            onClick={handleSubmit}
           />
           <div className="phone-number-description">
             {showSuccess && (
@@ -633,14 +633,9 @@ export const PhoneNumberCallout: React.FC<{
           </div>
         </div>
         <div className="phone-number-submit__mobile">
-          <Button
-            labelText="Submit"
-            variant="secondary"
-            size="small"
-            onClick={handleSubmit}
-          />
+          <Button labelText="Submit" variant="secondary" size="small" />
         </div>
-      </div>
+      </form>
     </div>
   );
 };

--- a/src/Components/Pages/Results/Results.tsx
+++ b/src/Components/Pages/Results/Results.tsx
@@ -597,11 +597,7 @@ export const PhoneNumberCallout: React.FC<{
           We’ll use your answers to better advocate for your rights.
         </p>
       </div>
-      <form
-        className="callout-box__column"
-        onSubmit={handleSubmit}
-        aria-label="Phone number"
-      >
+      <form className="callout-box__column" onSubmit={handleSubmit}>
         <div className="phone-number-input-container">
           <TextInput
             labelText="Phone number"


### PR DESCRIPTION
We noticed that on all out inputs you can press enter to submit, but that was because we weren't actually using a `form` element for these - specifically the rent calculator, the address search on homepage, and the phone number submission component. I've updated all of these to just change existing container divs into forms and added `preventDefault()` so the page doesn't reload. 