### PR TITLE
fix staten island name format for db

### DIFF
--- a/src/Components/Pages/Home/Home.tsx
+++ b/src/Components/Pages/Home/Home.tsx
@@ -9,10 +9,11 @@ import { FormFields } from "../Form/Survey";
 import { useSendGceData } from "../../../api/hooks";
 import { GCEPostData, GCEUser } from "../../../types/APIDataTypes";
 import { Header } from "../../Header/Header";
-import { ProgressStep, toMacroCase } from "../../../helpers";
+import { ProgressStep } from "../../../helpers";
 import { JFCLLinkExternal, JFCLLinkInternal } from "../../JFCLLink";
-import "./Home.scss";
+import { cleanAddressFields } from "../../../api/helpers";
 import { gtmPush } from "../../../google-tag-manager";
+import "./Home.scss";
 
 export type Address = {
   bbl: string;
@@ -53,11 +54,7 @@ export const Home: React.FC = () => {
     setAddress(geoAddress);
     const postData: GCEPostData = {
       id: sessionUser?.id,
-      bbl: geoAddress.bbl,
-      house_number: geoAddress.houseNumber,
-      street_name: geoAddress.streetName,
-      borough: toMacroCase(geoAddress.borough),
-      zipcode: geoAddress.zipcode,
+      ...cleanAddressFields(geoAddress),
     };
 
     try {

--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -89,12 +89,16 @@ export const cleanFormFields = ({
   };
 };
 
+function toMacroCase(x: string) {
+  return x.replace(/\s+/g, "_").toUpperCase();
+}
+
 export const cleanAddressFields = (address: Address) => {
   return {
     bbl: address.bbl,
     house_number: address.houseNumber,
     street_name: address.streetName,
-    borough: address.borough,
+    borough: toMacroCase(address.borough),
     zipcode: address.zipcode,
   };
 };

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -17,10 +17,6 @@ export function toTitleCase(x: string) {
   );
 }
 
-export function toMacroCase(x: string) {
-  return x.replace(/\s+/g, "_").toUpperCase();
-}
-
 export const formatGeosearchAddress = (
   properties: GeoSearchProperties | undefined
 ): string =>


### PR DESCRIPTION
Same issue we were having in https://github.com/JustFixNYC/gce-screener/pull/119 with `"STATEN ISLAND"` vs `"STATEN_ISLAND"`, but making sure this is also applied on the results page. Now use the same helper function on home and results page when sending data to DB