### PR TITLE
add ? for window.print

### DIFF
--- a/src/Components/ShareButtons/ShareButtons.tsx
+++ b/src/Components/ShareButtons/ShareButtons.tsx
@@ -37,7 +37,7 @@ export const ShareButtons: React.FC<ShareButtonsProps> = ({
       className="share-button share-button__download jfcl-link"
       key={key}
       onClick={() => {
-        window.print();
+        window?.print();
         gtmPush("gce_share_button", { type: "download" });
       }}
     >
@@ -51,7 +51,7 @@ export const ShareButtons: React.FC<ShareButtonsProps> = ({
       className="share-button share-button__print jfcl-link"
       key={key}
       onClick={() => {
-        window.print();
+        window?.print();
         gtmPush("gce_share_button", { type: "download" });
       }}
     >


### PR DESCRIPTION
got an error through rollbar for window being undefined when trying to call print: `undefined is not an object (evaluating 'window.webkit.messageHandlers.print.postMessage')`, so adding `?` for `window?.print()` to avoid this