### PR TITLE
fix mistake in number of additional units for portfolio size

### DIFF
--- a/src/Components/Pages/PortfolioSize/PortfolioSize.tsx
+++ b/src/Components/Pages/PortfolioSize/PortfolioSize.tsx
@@ -194,8 +194,8 @@ export const PortfolioSize: React.FC = () => {
                       {`Remember, your building has ${bldgData.unitsres}
                     apartments, so `}
                       <strong>{`you only need to confirm that your landlord
-                    owns ${10 - bldgData.unitsres} additional ${
-                        10 - bldgData.unitsres == 1 ? "apartment" : "apartments"
+                    owns ${11 - bldgData.unitsres} additional ${
+                        11 - bldgData.unitsres == 1 ? "apartment" : "apartments"
                       } across other buildings.`}</strong>
                     </>
                   </InfoBox>


### PR DESCRIPTION
The size requirement is more than 10 total units, but the copy saying how many additional units you need to find to qualify was counting up to 10 not 11. 