### PR TITLE
Update CPI and rent levels with new DHCR published numbers

### DIFF
--- a/src/Components/KYRContent/KYRContent.tsx
+++ b/src/Components/KYRContent/KYRContent.tsx
@@ -7,9 +7,7 @@ import {
 import { formatMoney, urlMyGov } from "../../helpers";
 import { JFCLLinkExternal, JFCLLinkInternal } from "../JFCLLink";
 import { CoverageResult } from "../../types/APIDataTypes";
-
-// This needs to be updated each year when DHCR publishes the new number
-export const CPI = 3.79;
+import { CPI } from "../Pages/RentCalculator/RentCalculator";
 
 type KYRContentBoxProps = Omit<ContentBoxProps, "children"> & {
   children?: React.ReactNode;

--- a/src/Components/KYRContent/KYRContent.tsx
+++ b/src/Components/KYRContent/KYRContent.tsx
@@ -9,7 +9,7 @@ import { JFCLLinkExternal, JFCLLinkInternal } from "../JFCLLink";
 import { CoverageResult } from "../../types/APIDataTypes";
 
 // This needs to be updated each year when DHCR publishes the new number
-export const CPI = 3.82;
+export const CPI = 3.79;
 
 type KYRContentBoxProps = Omit<ContentBoxProps, "children"> & {
   children?: React.ReactNode;

--- a/src/Components/Pages/RentCalculator/RentCalculator.tsx
+++ b/src/Components/Pages/RentCalculator/RentCalculator.tsx
@@ -15,6 +15,8 @@ import { gtmPush } from "../../../google-tag-manager";
 
 // This needs to be updated each year when DHCR publishes the new number
 export const CPI = 3.79;
+// This date isn't actually official, just what HPD has on their site. 
+// The law never included when the changes come into effect
 export const CPI_EFFECTIVE_DATE = "February 19, 2025";
 
 export const RentCalculator: React.FC = () => {

--- a/src/Components/Pages/RentCalculator/RentCalculator.tsx
+++ b/src/Components/Pages/RentCalculator/RentCalculator.tsx
@@ -4,7 +4,6 @@ import { useAccordionsOpenForPrint } from "../../../hooks/useAccordionsOpenForPr
 import { JFCLLinkInternal } from "../../JFCLLink";
 import "./RentCalculator.scss";
 import {
-  CPI,
   GoodCauseProtections,
   UniversalProtections,
 } from "../../KYRContent/KYRContent";
@@ -13,6 +12,10 @@ import { Button, TextInput } from "@justfixnyc/component-library";
 import { useState } from "react";
 import { PhoneNumberCallout } from "../Results/Results";
 import { gtmPush } from "../../../google-tag-manager";
+
+// This needs to be updated each year when DHCR publishes the new number
+export const CPI = 3.79;
+export const CPI_EFFECTIVE_DATE = "February 19, 2025";
 
 export const RentCalculator: React.FC = () => {
   useAccordionsOpenForPrint();
@@ -100,11 +103,11 @@ export const RentCalculator: React.FC = () => {
               increase could be found unreasonable by housing court.
             </p>
             <p>
-              The Good Cause law establishes a Reasonable Rent Increase, which
+              {`The Good Cause law establishes a Reasonable Rent Increase, which
               is set every year at the rate of inflation plus 5%, with a maximum
-              of 10% total. As of May 1, 2024, the rate of inflation for New
-              York City is 3.82%, meaning that the current local Reasonable Rent
-              Increase is 8.82%.
+              of 10% total. As of ${CPI_EFFECTIVE_DATE}, the rate of inflation for New
+              York City is ${CPI}%, meaning that the current local Reasonable Rent
+              Increase is ${CPI + 5}%.`}
             </p>
             <p>
               Note: Landlords can increase the rent beyond the Reasonable Rent

--- a/src/hooks/useCriteriaResults.tsx
+++ b/src/hooks/useCriteriaResults.tsx
@@ -12,6 +12,15 @@ import {
 } from "../helpers";
 import { JFCLLinkExternal, JFCLLinkInternal } from "../Components/JFCLLink";
 
+// These values need to be updated annually. They are published by DHCR on or before August 1 each year
+const RENT_CUTOFFS = {
+  STUDIO: 5895,
+  "1": 6152,
+  "2": 6811,
+  "3": 8489,
+  "4+": 9158,
+};
+
 export type Criteria =
   | "portfolioSize"
   | "landlord"
@@ -168,16 +177,7 @@ function eligibilityLandlord(criteriaData: CriteriaData): CriterionDetails {
 
 function eligibilityRent(criteriaData: CriteriaData): CriterionDetails {
   const { bedrooms, rent: rentString } = criteriaData;
-
   const rent = parseFloat(rentString || "");
-
-  const rentCutoffs = {
-    STUDIO: "$5,846",
-    "1": "$6,005",
-    "2": "$6,742",
-    "3": "$8,413",
-    "4+": "$9,065",
-  };
   const criteria = "rent";
   let determination: CriterionResult;
 
@@ -186,17 +186,20 @@ function eligibilityRent(criteriaData: CriteriaData): CriterionDetails {
 
   const requirement = `For a ${
     bedrooms === "STUDIO" ? "studio" : `${bedrooms} bedroom`
-  }, the monthly total rent must be less than ${rentCutoffs[bedrooms]}`;
+  }, the monthly total rent must be less than ${formatMoney(
+    RENT_CUTOFFS[bedrooms],
+    0
+  )}`;
   if (bedrooms === "STUDIO") {
-    determination = rent < 5846 ? "ELIGIBLE" : "INELIGIBLE";
+    determination = rent < RENT_CUTOFFS["STUDIO"] ? "ELIGIBLE" : "INELIGIBLE";
   } else if (bedrooms === "1") {
-    determination = rent < 6005 ? "ELIGIBLE" : "INELIGIBLE";
+    determination = rent < RENT_CUTOFFS["1"] ? "ELIGIBLE" : "INELIGIBLE";
   } else if (bedrooms === "2") {
-    determination = rent < 6742 ? "ELIGIBLE" : "INELIGIBLE";
+    determination = rent < RENT_CUTOFFS["2"] ? "ELIGIBLE" : "INELIGIBLE";
   } else if (bedrooms === "3") {
-    determination = rent < 8413 ? "ELIGIBLE" : "INELIGIBLE";
+    determination = rent < RENT_CUTOFFS["3"] ? "ELIGIBLE" : "INELIGIBLE";
   } else {
-    determination = rent < 9065 ? "ELIGIBLE" : "INELIGIBLE";
+    determination = rent < RENT_CUTOFFS["4+"] ? "ELIGIBLE" : "INELIGIBLE";
   }
 
   const userValue = `You reported that your rent is ${formatMoney(rent, 0)}.`;


### PR DESCRIPTION
The new CPI number has been published, and this updated to the new value: 3.79%

Sources:
* DHCR published this fact sheet with the newest CPI: https://hcr.ny.gov/system/files/documents/2025/04/gce-fact-sheet-04.23.25-update.pdf#page=7
* HPD's know your rights page uses the same new CPI, and says "as of February 19, 2025", so I included updated the date we had on the site as well. 

This also makes use of variables for the copy on the rent calculator page, moves the CPI var to that page (feels like the logical place to set it now), and also adds a var for the date of the new CPI  - this listed on HPD's website as February 19, 2025. 

It turns out that in the law it was never specified when the new CPI/Rent numbers take effect, only that they must be published on/before Aug 1 each year. So for now we'll just keep this language of "as of February 19, 2025" that HPD is using, until later things are clarified.

I also updated the rent levels, which are also updated in the above DHCR document.

[sc-16396]