### PR TITLE
Add phone number capture modal popup on results page

### DIFF
--- a/src/Components/Modal/Modal.scss
+++ b/src/Components/Modal/Modal.scss
@@ -42,12 +42,12 @@
     @include body_standard_desktop;
 
     .modal__header {
+      margin: 0 5rem 1rem 0;
+      text-wrap: pretty;
       @include h3_desktop;
       @include for-phone-only {
         @include h3_mobile;
       }
-      margin: 0 5rem 1rem 0;
-      text-wrap: pretty;
     }
 
     .callout-box {

--- a/src/Components/Modal/Modal.tsx
+++ b/src/Components/Modal/Modal.tsx
@@ -10,6 +10,7 @@ export interface ModalProps {
   hasCloseBtn?: boolean;
   onClose?: () => void;
   header?: string;
+  className?: string;
   children: React.ReactNode;
 }
 
@@ -18,6 +19,7 @@ const Modal = ({
   onClose,
   hasCloseBtn = true,
   header,
+  className,
   children,
 }: ModalProps) => {
   const modalRef = useRef<HTMLDialogElement>(null);
@@ -59,7 +61,7 @@ const Modal = ({
   return (
     <dialog
       ref={modalRef}
-      className={classNames("modal", hasCloseBtn && "has-close")}
+      className={classNames("modal", className, hasCloseBtn && "has-close")}
       onKeyDown={handleKeyDown}
       onClick={handleClickOutside}
     >

--- a/src/Components/Pages/PortfolioSize/PortfolioSize.tsx
+++ b/src/Components/Pages/PortfolioSize/PortfolioSize.tsx
@@ -106,9 +106,9 @@ export const PortfolioSize: React.FC = () => {
               <InfoBox color="blue">
                 <>
                   <strong>Tip:</strong> We recommend doing the following
-                  research on a desktop computer. If you have not already, please
-                  watch the video, above, for step-by-step instructions on how
-                  to complete Steps 1 and 2.
+                  research on a desktop computer. If you have not already,
+                  please watch the video, above, for step-by-step instructions
+                  on how to complete Steps 1 and 2.
                 </>
               </InfoBox>
             </ContentBoxItem>

--- a/src/Components/Pages/RentCalculator/RentCalculator.tsx
+++ b/src/Components/Pages/RentCalculator/RentCalculator.tsx
@@ -131,7 +131,11 @@ export const RentCalculator: React.FC = () => {
             </JFCLLinkInternal>
           </div>
           <div className="divider__print" />
-          <PhoneNumberCallout gtmId="rent-calculator-page" />
+          <PhoneNumberCallout
+            headerText="Help build tenant power in NYC"
+            bodyText="We’ll text you once a year to learn about your housing conditions. We’ll use your answers to better advocate for your rights."
+            gtmId="rent-calculator-page"
+          />
 
           <GoodCauseProtections
             rent={showRentInput ? Number(rentInput) : undefined}

--- a/src/Components/Pages/Results/Results.tsx
+++ b/src/Components/Pages/Results/Results.tsx
@@ -53,7 +53,7 @@ import {
 function getCookie(name: string) {
   const value = `; ${document.cookie}`;
   const parts = value.split(`; ${name}=`);
-  if (parts.length === 2) return parts.pop()?.split(';').shift();
+  if (parts.length === 2) return parts.pop()?.split(";").shift();
 }
 
 function setCookie(name: string, value: string, days: number) {

--- a/src/Components/Pages/Results/Results.tsx
+++ b/src/Components/Pages/Results/Results.tsx
@@ -38,7 +38,12 @@ import {
 } from "../../KYRContent/KYRContent";
 import { Header } from "../../Header/Header";
 import { useSessionStorage } from "../../../hooks/useSessionStorage";
-import { ProgressStep, toTitleCase } from "../../../helpers";
+import {
+  getCookie,
+  ProgressStep,
+  setCookie,
+  toTitleCase,
+} from "../../../helpers";
 import { ShareButtons } from "../../ShareButtons/ShareButtons";
 import "./Results.scss";
 import { useAccordionsOpenForPrint } from "../../../hooks/useAccordionsOpenForPrint";
@@ -49,17 +54,6 @@ import {
   PhoneNumberCallout,
   PhoneNumberModal,
 } from "../../PhoneNumberCallout/PhoneNumberCallout";
-
-function getCookie(name: string) {
-  const value = `; ${document.cookie}`;
-  const parts = value.split(`; ${name}=`);
-  if (parts.length === 2) return parts.pop()?.split(";").shift();
-}
-
-function setCookie(name: string, value: string, days: number) {
-  const expires = new Date(Date.now() + days * 864e5).toUTCString();
-  document.cookie = `${name}=${value}; expires=${expires}; path=/`;
-}
 
 export const Results: React.FC = () => {
   const { address, fields, user } = useLoaderData() as {
@@ -99,7 +93,6 @@ export const Results: React.FC = () => {
 
   const [showPhoneModal, setShowPhoneModal] = useState(false);
   const [hasShownPhoneModal, setHasShownPhoneModal] = useState(false);
-  // Remove contentSectionRef and useInViewPort logic
 
   useEffect(() => {
     if (hasShownPhoneModal || getCookie("phone_modal_shown")) return;
@@ -122,7 +115,7 @@ export const Results: React.FC = () => {
   // When modal closes, set cookie
   const handlePhoneModalClose = () => {
     setShowPhoneModal(false);
-    setCookie("phone_modal_shown", "1", 1); // 1 day expiration
+    setCookie("phone_modal_shown", "1");
   };
 
   const resultDataReady = !!coverageResult && !!criteriaResults?.building_class;
@@ -193,7 +186,7 @@ export const Results: React.FC = () => {
       </Header>
       <PhoneNumberModal
         coverageResult={coverageResult}
-        gtmId="results-page"
+        gtmId="results-page-modal"
         modalIsOpen={showPhoneModal}
         modalOnClose={handlePhoneModalClose}
       />

--- a/src/Components/Pages/Results/Results.tsx
+++ b/src/Components/Pages/Results/Results.tsx
@@ -45,7 +45,10 @@ import { useAccordionsOpenForPrint } from "../../../hooks/useAccordionsOpenForPr
 import { useSearchParamsURL } from "../../../hooks/useSearchParamsURL";
 import { JFCLLinkInternal } from "../../JFCLLink";
 import { gtmPush } from "../../../google-tag-manager";
-import { PhoneNumberCallout } from "../../PhoneNumberCallout/PhoneNumberCallout";
+import {
+  PhoneNumberCallout,
+  PhoneNumberModal,
+} from "../../PhoneNumberCallout/PhoneNumberCallout";
 
 export const Results: React.FC = () => {
   const { address, fields, user } = useLoaderData() as {
@@ -82,6 +85,8 @@ export const Results: React.FC = () => {
 
   useAccordionsOpenForPrint();
   useSearchParamsURL(setSearchParams, address, fields, user);
+
+  const [showPhoneModal, setShowPhoneModal] = useState(false);
 
   const resultDataReady = !!coverageResult && !!criteriaResults?.building_class;
   useEffect(() => {
@@ -149,7 +154,14 @@ export const Results: React.FC = () => {
           View tenant protection information on following pages
         </div>
       </Header>
-
+      {/* TODO: this button is just for debugging until the event listening is set up */}
+      <Button labelText="modal" onClick={() => setShowPhoneModal(true)} />
+      <PhoneNumberModal
+        coverageResult={coverageResult}
+        gtmId="results-page"
+        modalIsOpen={showPhoneModal}
+        modalOnClose={() => setShowPhoneModal(false)}
+      />
       <div className="content-section">
         <div className="content-section__content">
           {coverageResult === "UNKNOWN" && bldgData && criteriaDetails && (

--- a/src/Components/PhoneNumberCallout/PhoneNumberCallout.scss
+++ b/src/Components/PhoneNumberCallout/PhoneNumberCallout.scss
@@ -87,10 +87,32 @@
   }
 }
 
-// TODO: I wasn't able to finish styling the new modal
 .phone-capture-modal {
-  max-width: 26rem;
+  max-width: 30rem;
+
+  .jfcl-text-input {
+    margin-bottom: .5rem;
+  }
+
+  .phone-number-description {
+    margin-bottom: 2rem;
+    @include small_text_desktop;
+    @include for-phone-only {
+      @include small_text_mobile;
+    }
+  }
+  
   .phone-number-button-container {
     display: flex;
+    align-items: center;
+
+    > button {
+      flex: 1 1 0;
+      width: 100%;
+    }
+
+    > button:not(:last-child) {
+      margin-right: 1.25rem;
+    }
   }
 }

--- a/src/Components/PhoneNumberCallout/PhoneNumberCallout.scss
+++ b/src/Components/PhoneNumberCallout/PhoneNumberCallout.scss
@@ -91,7 +91,7 @@
   max-width: 30rem;
 
   .jfcl-text-input {
-    margin-bottom: .5rem;
+    margin-bottom: 0.5rem;
   }
 
   .phone-number-description {
@@ -101,7 +101,7 @@
       @include small_text_mobile;
     }
   }
-  
+
   .phone-number-button-container {
     display: flex;
     align-items: center;

--- a/src/Components/PhoneNumberCallout/PhoneNumberCallout.scss
+++ b/src/Components/PhoneNumberCallout/PhoneNumberCallout.scss
@@ -86,3 +86,11 @@
     }
   }
 }
+
+// TODO: I wasn't able to finish styling the new modal
+.phone-capture-modal {
+  max-width: 26rem;
+  .phone-number-button-container {
+    display: flex;
+  }
+}

--- a/src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx
+++ b/src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx
@@ -217,6 +217,9 @@ const PhoneNumberModalUI: React.FC<PhoneNumberUIProps> = ({
           value={phoneNumber}
           onChange={handleInputChange}
         />
+        <div className="phone-number-description">
+          We will never call you or share your phone number. You can opt-out at any time.
+        </div>
         <div className="phone-number-button-container">
           <Button
             className="phone-number-cancel"
@@ -232,7 +235,7 @@ const PhoneNumberModalUI: React.FC<PhoneNumberUIProps> = ({
             type="submit"
           />
         </div>
-        <div className="phone-number-description">
+        <div className="phone-number-submit-message">
           {showSuccess && (
             <div className="success-message">
               <Icon icon="check" />
@@ -245,8 +248,6 @@ const PhoneNumberModalUI: React.FC<PhoneNumberUIProps> = ({
               Something went wrong. Try again later.
             </div>
           )}
-          We will never call you or share your phone number. You can opt-out at
-          any time.
         </div>
       </form>
     </Modal>

--- a/src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx
+++ b/src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx
@@ -20,6 +20,8 @@ interface PhoneNumberUIProps {
   showError: boolean;
   modalIsOpen?: boolean;
   modalOnClose?: () => void;
+  headerText: string;
+  bodyText: string;
 }
 
 interface PhoneNumberCaptureProps {
@@ -27,11 +29,20 @@ interface PhoneNumberCaptureProps {
   coverageResult?: CoverageResult;
   gtmId?: string;
   modalOnClose?: () => void;
+  headerText?: string;
+  bodyText?: string;
 }
 
 const PhoneNumberCapture: React.FC<PhoneNumberCaptureProps> = (props) => {
-  const { PhoneNumberUI, coverageResult, gtmId, modalOnClose, ...UIProps } =
-    props;
+  const {
+    PhoneNumberUI,
+    coverageResult,
+    gtmId,
+    modalOnClose,
+    headerText = "Save your result to your phone",
+    bodyText = "Get a text with a unique URL to your results page.",
+    ...UIProps
+  } = props;
   const [phoneNumber, setPhoneNumber] = useState("");
   const [showFieldError, setShowFieldError] = useState(false);
   const [showError, setShowError] = useState(false);
@@ -84,10 +95,16 @@ const PhoneNumberCapture: React.FC<PhoneNumberCaptureProps> = (props) => {
     }
     try {
       const sendData = async () => {
+        const resultUrlParam =
+          window.location.pathname === "/results"
+            ? {
+                result_url: window.location.href,
+              }
+            : {};
         const postData = {
           id: user?.id,
           phone_number: parseInt(cleaned),
-          result_url: window.location.href,
+          ...resultUrlParam,
         };
         const userResp = (await trigger(postData)) as GCEUser;
         if (!user?.id) setUser(userResp);
@@ -118,6 +135,8 @@ const PhoneNumberCapture: React.FC<PhoneNumberCaptureProps> = (props) => {
       handleInputChange={handleInputChange}
       showSuccess={showSuccess}
       showError={showError}
+      headerText={headerText}
+      bodyText={bodyText}
     />
   );
 };
@@ -129,14 +148,14 @@ const PhoneNumberCalloutUI: React.FC<PhoneNumberUIProps> = ({
   handleInputChange,
   showSuccess,
   showError,
+  headerText,
+  bodyText,
 }) => {
   return (
     <div className="phone-number-callout-box">
       <div className="callout-box__column">
-        <span className="callout-box__header">
-          Save your result to your phone
-        </span>
-        <p>Get a text with a unique URL to your results page.</p>
+        <span className="callout-box__header">{headerText}</span>
+        <p>{bodyText}</p>
       </div>
       <form className="callout-box__column" onSubmit={handleSubmit}>
         <div className="phone-number-input-container">
@@ -197,16 +216,18 @@ const PhoneNumberModalUI: React.FC<PhoneNumberUIProps> = ({
   showError,
   modalIsOpen,
   modalOnClose,
+  headerText,
+  bodyText,
 }) => {
   return (
     <Modal
-      header="Save your result to your phone"
+      header={headerText}
       isOpen={modalIsOpen!}
       onClose={modalOnClose}
       hasCloseBtn={true}
       className="phone-capture-modal"
     >
-      <p>Get a text with a unique URL to your results page.</p>
+      <p>{bodyText}</p>
       <form className="phone-number-input-container" onSubmit={handleSubmit}>
         <TextInput
           labelText="Phone number"

--- a/src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx
+++ b/src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx
@@ -85,6 +85,7 @@ const PhoneNumberCapture: React.FC<PhoneNumberCaptureProps> = (props) => {
         const postData = {
           id: user?.id,
           phone_number: parseInt(cleaned),
+          result_url: window.location.href,
         };
         const userResp = (await trigger(postData)) as GCEUser;
         if (!user?.id) setUser(userResp);
@@ -127,17 +128,14 @@ const PhoneNumberCalloutUI: React.FC<PhoneNumberUIProps> = ({
     <div className="phone-number-callout-box">
       <div className="callout-box__column">
         <span className="callout-box__header">
-          Help build tenant power in NYC
+          Save your result to your phone
         </span>
-        <p>
-          Get involved in the housing justice movement. We will text you with
-          opportunities to help expand Good Cause and other tenant rights.
-        </p>
+        <p>Get a text with a unique URL to your results page.</p>
       </div>
       <form className="callout-box__column" onSubmit={handleSubmit}>
         <div className="phone-number-input-container">
           <TextInput
-            labelText="Phone number"
+            labelText="Phone number (optional)"
             placeholder="(123) 456-7890"
             invalid={showFieldError}
             invalidText="Enter a valid phone number"
@@ -166,8 +164,8 @@ const PhoneNumberCalloutUI: React.FC<PhoneNumberUIProps> = ({
                 Something went wrong. Try again later.
               </div>
             )}
-            We will never call you or share your phone number. You can opt-out
-            at any time.
+            We will never call you or share your phone number. We may text you
+            later in the year to see how things are going. Opt-out at any time.
           </div>
         </div>
         <div className="phone-number-submit__mobile">
@@ -196,16 +194,13 @@ const PhoneNumberModalUI: React.FC<PhoneNumberUIProps> = ({
 }) => {
   return (
     <Modal
-      header="Help build tenant power in NYC"
+      header="Save your result to your phone"
       isOpen={modalIsOpen!}
       onClose={modalOnClose}
       hasCloseBtn={true}
       className="phone-capture-modal"
     >
-      <p>
-        Get a text from us once a year to tell us about your housing conditions.
-        We’ll use your answers to better advocate for your rights.
-      </p>
+      <p>Get a text with a unique URL to your results page.</p>
       <form className="phone-number-input-container" onSubmit={handleSubmit}>
         <TextInput
           labelText="Phone number"
@@ -218,7 +213,8 @@ const PhoneNumberModalUI: React.FC<PhoneNumberUIProps> = ({
           onChange={handleInputChange}
         />
         <div className="phone-number-description">
-          We will never call you or share your phone number. You can opt-out at any time.
+          We will never call you or share your phone number. We may text you
+          later in the year to see how things are going. Opt-out at any time.{" "}
         </div>
         <div className="phone-number-button-container">
           <Button

--- a/src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx
+++ b/src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx
@@ -7,20 +7,29 @@ import { CoverageResult, GCEUser } from "../../types/APIDataTypes";
 import { gtmPush } from "../../google-tag-manager";
 import { useSendGceData } from "../../api/hooks";
 import { useSessionStorage } from "../../hooks/useSessionStorage";
+import Modal from "../Modal/Modal";
 
 import "./PhoneNumberCallout.scss";
 
-export const PhoneNumberCallout: React.FC<{
-  headerText?: string;
-  bodyText?: string;
+interface PhoneNumberUIProps {
+  handleSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  showFieldError: boolean;
+  phoneNumber: string;
+  handleInputChange: React.ChangeEventHandler<HTMLInputElement>;
+  showSuccess: boolean;
+  showError: boolean;
+  modalIsOpen?: boolean;
+  modalOnClose?: () => void;
+}
+
+interface PhoneNumberCaptureProps {
+  PhoneNumberUI: React.FC<PhoneNumberUIProps>;
   coverageResult?: CoverageResult;
   gtmId?: string;
-}> = ({
-  headerText = "Help build tenant power in NYC",
-  bodyText = "We’ll text you once a year to learn about your housing conditions. We’ll use your answers to better advocate for your rights.",
-  coverageResult,
-  gtmId,
-}) => {
+}
+
+const PhoneNumberCapture: React.FC<PhoneNumberCaptureProps> = (props) => {
+  const { PhoneNumberUI, coverageResult, gtmId, ...UIProps } = props;
   const [phoneNumber, setPhoneNumber] = useState("");
   const [showFieldError, setShowFieldError] = useState(false);
   const [showError, setShowError] = useState(false);
@@ -94,10 +103,36 @@ export const PhoneNumberCallout: React.FC<{
   };
 
   return (
+    <PhoneNumberUI
+      {...UIProps}
+      handleSubmit={handleSubmit}
+      showFieldError={showFieldError}
+      phoneNumber={phoneNumber}
+      handleInputChange={handleInputChange}
+      showSuccess={showSuccess}
+      showError={showError}
+    />
+  );
+};
+
+const PhoneNumberCalloutUI: React.FC<PhoneNumberUIProps> = ({
+  handleSubmit,
+  showFieldError,
+  phoneNumber,
+  handleInputChange,
+  showSuccess,
+  showError,
+}) => {
+  return (
     <div className="phone-number-callout-box">
       <div className="callout-box__column">
-        <span className="callout-box__header">{headerText}</span>
-        <p>{bodyText}</p>
+        <span className="callout-box__header">
+          Help build tenant power in NYC
+        </span>
+        <p>
+          Get involved in the housing justice movement. We will text you with
+          opportunities to help expand Good Cause and other tenant rights.
+        </p>
       </div>
       <form className="callout-box__column" onSubmit={handleSubmit}>
         <div className="phone-number-input-container">
@@ -141,4 +176,86 @@ export const PhoneNumberCallout: React.FC<{
       </form>
     </div>
   );
+};
+
+export const PhoneNumberCallout: React.FC<
+  Omit<PhoneNumberCaptureProps, "PhoneNumberUI">
+> = (props) => {
+  return <PhoneNumberCapture {...props} PhoneNumberUI={PhoneNumberCalloutUI} />;
+};
+
+const PhoneNumberModalUI: React.FC<PhoneNumberUIProps> = ({
+  handleSubmit,
+  showFieldError,
+  phoneNumber,
+  handleInputChange,
+  showSuccess,
+  showError,
+  modalIsOpen,
+  modalOnClose,
+}) => {
+  return (
+    <Modal
+      header="Help build tenant power in NYC"
+      isOpen={modalIsOpen!}
+      onClose={modalOnClose}
+      hasCloseBtn={true}
+      className="phone-capture-modal"
+    >
+      <p>
+        Get a text from us once a year to tell us about your housing conditions.
+        We’ll use your answers to better advocate for your rights.
+      </p>
+      <form className="phone-number-input-container" onSubmit={handleSubmit}>
+        <TextInput
+          labelText="Phone number"
+          placeholder="(123) 456-7890"
+          invalid={showFieldError}
+          invalidText="Enter a valid phone number"
+          id="phone-number-input"
+          name="phone-number-input"
+          value={phoneNumber}
+          onChange={handleInputChange}
+        />
+        <div className="phone-number-button-container">
+          <Button
+            className="phone-number-cancel"
+            labelText="No, thanks"
+            variant="tertiary"
+            type="button"
+            onClick={modalOnClose}
+          />
+          <Button
+            className="phone-number-submit"
+            labelText="Submit"
+            variant="primary"
+            type="submit"
+          />
+        </div>
+        <div className="phone-number-description">
+          {showSuccess && (
+            <div className="success-message">
+              <Icon icon="check" />
+              Phone number submitted
+            </div>
+          )}
+          {showError && (
+            <div className="error-message">
+              <Icon icon="circleExclamation" />
+              Something went wrong. Try again later.
+            </div>
+          )}
+          We will never call you or share your phone number. You can opt-out at
+          any time.
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+export const PhoneNumberModal: React.FC<
+  Omit<PhoneNumberCaptureProps, "PhoneNumberUI"> &
+    Pick<PhoneNumberUIProps, "modalIsOpen" | "modalOnClose">
+> = (props) => {
+  return <PhoneNumberCapture {...props} PhoneNumberUI={PhoneNumberModalUI} />;
 };

--- a/src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx
+++ b/src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx
@@ -26,10 +26,12 @@ interface PhoneNumberCaptureProps {
   PhoneNumberUI: React.FC<PhoneNumberUIProps>;
   coverageResult?: CoverageResult;
   gtmId?: string;
+  modalOnClose?: () => void;
 }
 
 const PhoneNumberCapture: React.FC<PhoneNumberCaptureProps> = (props) => {
-  const { PhoneNumberUI, coverageResult, gtmId, ...UIProps } = props;
+  const { PhoneNumberUI, coverageResult, gtmId, modalOnClose, ...UIProps } =
+    props;
   const [phoneNumber, setPhoneNumber] = useState("");
   const [showFieldError, setShowFieldError] = useState(false);
   const [showError, setShowError] = useState(false);
@@ -92,7 +94,11 @@ const PhoneNumberCapture: React.FC<PhoneNumberCaptureProps> = (props) => {
       };
       sendData();
       setShowFieldError(false);
-      setShowSuccess(true);
+      if (modalOnClose) {
+        modalOnClose();
+      } else {
+        setShowSuccess(true);
+      }
       gtmPush("gce_phone_submit", {
         gce_result: coverageResult,
         from: gtmId,
@@ -254,5 +260,12 @@ export const PhoneNumberModal: React.FC<
   Omit<PhoneNumberCaptureProps, "PhoneNumberUI"> &
     Pick<PhoneNumberUIProps, "modalIsOpen" | "modalOnClose">
 > = (props) => {
-  return <PhoneNumberCapture {...props} PhoneNumberUI={PhoneNumberModalUI} />;
+  const { modalOnClose, ...otherProps } = props;
+  return (
+    <PhoneNumberCapture
+      {...otherProps}
+      PhoneNumberUI={PhoneNumberModalUI}
+      modalOnClose={modalOnClose}
+    />
+  );
 };

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -221,9 +221,9 @@ export const getObjFromEncodedParam = (
 export const getCookie = (name: string) => {
   const value = `; ${document.cookie}`;
   const parts = value.split(`; ${name}=`);
-  if (parts.length === 2) return parts.pop()?.split(';').shift();
-}
+  if (parts.length === 2) return parts.pop()?.split(";").shift();
+};
 
 export const setCookie = (name: string, value: string) => {
   document.cookie = `${name}=${value}; path=/`;
-}
+};

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -215,3 +215,15 @@ export const getObjFromEncodedParam = (
   const encodedStr = params.get(key);
   return encodedStr ? decodeFromURI(encodedStr) : null;
 };
+
+// Session based cookie setter and getter
+
+export const getCookie = (name: string) => {
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${name}=`);
+  if (parts.length === 2) return parts.pop()?.split(';').shift();
+}
+
+export const setCookie = (name: string, value: string) => {
+  document.cookie = `${name}=${value}; path=/`;
+}

--- a/src/hooks/useCriteriaResults.tsx
+++ b/src/hooks/useCriteriaResults.tsx
@@ -470,10 +470,9 @@ function eligibilitySubsidy(criteriaData: CriteriaData): CriterionDetails {
         <>
           You reported that your building is subsidized, and we are using your
           answer as part of our coverage assessment. Note: publicly available
-          data sources indicate that your building is part of NYCHA or PACT/RAD.
-          {" "}{sourceLink}{" "}
-          If those sources are correct, then you may already have stronger
-          tenant protections than other subsidized housing programs.
+          data sources indicate that your building is part of NYCHA or PACT/RAD.{" "}
+          {sourceLink} If those sources are correct, then you may already have
+          stronger tenant protections than other subsidized housing programs.
         </>
       );
     } else {
@@ -485,7 +484,7 @@ function eligibilitySubsidy(criteriaData: CriteriaData): CriterionDetails {
           You reported that your building is not part of any subsidized housing
           programs, and we are using your answer as part of our coverage
           assessment. Note: publicly available data sources indicate that your
-          building is part of NYCHA or PACT/RAD.{" "}{sourceLink}{" "}If those sources
+          building is part of NYCHA or PACT/RAD. {sourceLink} If those sources
           are correct, you may have existing tenant protections through NYCHA or
           PACT/RAD.
         </>

--- a/src/types/APIDataTypes.ts
+++ b/src/types/APIDataTypes.ts
@@ -91,4 +91,5 @@ export type GCEPostData = {
   result_coverage?: CoverageResult;
   result_criteria?: CriteriaResults;
   phone_number?: number;
+  result_url?: string;
 };


### PR DESCRIPTION
Add a popup modal on the results page to capture user phone numbers, and use cookies so it's only ever shown once.

This refactors the phone number capture model to separate the logic (form, api call, error/success states, etc) and the UI, so that we can add a modal version without repeating all the logic.

For now I have this PR from the branch with the other GCE changes, since there are some modal changes there needed here.

To-dos: 
- [x] Style the new phone capture modal
- [x] Add event listener in Results.tsx on either the scroll position, or maybe better, the visibility of some element below the criteria table, and have that change the state variable to show the modal.
- [x] Add the cookies saving/checking logic so that the modal is only shown if there is now cookie, and whenever the modal is closed is saves a cookie.

[sc-16492]