### PR TITLE
Show modal as soon as content section comes into view

### DIFF
--- a/src/Components/Pages/Results/Results.tsx
+++ b/src/Components/Pages/Results/Results.tsx
@@ -97,24 +97,30 @@ export const Results: React.FC = () => {
   useEffect(() => {
     if (hasShownPhoneModal || getCookie("phone_modal_shown")) return;
 
-    const contentSection = document.querySelector(".content-section");
+    const contentSection = document.querySelector(".content-section__content");
     if (!contentSection) return;
 
-    // Prevents modal from showing on page load by requiring user to scroll down a bit
+    // Checks if user has scrolled down at least a bit before showing modal
+    // Without this, the modal renders on page load
     const hasScrolled = () => {
       const scrollY = window.scrollY || window.pageYOffset;
       return scrollY > 100; // user has scrolled down at least 100px
     };
 
-    const observer = new IntersectionObserver((entries) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting && hasScrolled()) {
-          setShowPhoneModal(true);
-          setHasShownPhoneModal(true);
-          observer.disconnect();
-        }
-      });
-    });
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting && hasScrolled()) {
+            setShowPhoneModal(true);
+            setHasShownPhoneModal(true);
+            observer.disconnect();
+          }
+        });
+      },
+      {
+        threshold: 0.15, // Trigger when 15% of the element is visible
+      }
+    );
 
     observer.observe(contentSection);
 

--- a/src/Components/Pages/Results/Results.tsx
+++ b/src/Components/Pages/Results/Results.tsx
@@ -96,20 +96,29 @@ export const Results: React.FC = () => {
 
   useEffect(() => {
     if (hasShownPhoneModal || getCookie("phone_modal_shown")) return;
-    function handleScroll() {
+
+    const contentSection = document.querySelector(".content-section");
+    if (!contentSection) return;
+
+    // Prevents modal from showing on page load by requiring user to scroll down a bit
+    const hasScrolled = () => {
       const scrollY = window.scrollY || window.pageYOffset;
-      const windowHeight = window.innerHeight;
-      const docHeight = document.documentElement.scrollHeight;
-      // 65% down means user has scrolled at least 65% of the page height
-      const scrollPercent = (scrollY + windowHeight) / docHeight;
-      if (scrollPercent >= 0.65) {
-        setShowPhoneModal(true);
-        setHasShownPhoneModal(true);
-        window.removeEventListener("scroll", handleScroll);
-      }
-    }
-    window.addEventListener("scroll", handleScroll);
-    return () => window.removeEventListener("scroll", handleScroll);
+      return scrollY > 100; // user has scrolled down at least 100px
+    };
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting && hasScrolled()) {
+          setShowPhoneModal(true);
+          setHasShownPhoneModal(true);
+          observer.disconnect();
+        }
+      });
+    });
+
+    observer.observe(contentSection);
+
+    return () => observer.disconnect();
   }, [hasShownPhoneModal]);
 
   // When modal closes, set cookie


### PR DESCRIPTION
This PR changes the modal popup anchor to not be based on % of page scroll but the content section below the criteria table showing. Also adds a buffer (content-section must be 15% visible) so the modal isn't too disruptive to reading the criteria table.