### PR TITLE
add locale to all links, add a few missing strings

### DIFF
--- a/src/Components/Footer/Footer.tsx
+++ b/src/Components/Footer/Footer.tsx
@@ -3,85 +3,89 @@ import { Trans } from "@lingui/react/macro";
 
 import { LocaleToggle } from "../LocaleToggle/LocaleToggle";
 import "./Footer.scss";
+import { useLingui } from "@lingui/react";
 
-export const Footer: React.FC = () => (
-  <footer className="footer">
-    <div className="footer__content">
-      <div>
-        <div className="footer__locale-toggle">
-          <span>
-            <Trans>Language</Trans>:
-          </span>{" "}
-          <LocaleToggle />
+export const Footer: React.FC = () => {
+  const { i18n } = useLingui();
+  return (
+    <footer className="footer">
+      <div className="footer__content">
+        <div>
+          <div className="footer__locale-toggle">
+            <span>
+              <Trans>Language</Trans>:
+            </span>{" "}
+            <LocaleToggle />
+          </div>
+
+          <div className="footer__legal-disclaimer">
+            <span>
+              <Trans>Disclaimer</Trans>
+            </span>
+            <Trans>
+              The information on this website does not constitute legal advice
+              and must not be used as a substitute for the advice of a lawyer
+              qualified to give advice on legal issues pertaining to housing.
+            </Trans>
+          </div>
         </div>
-
-        <div className="footer__legal-disclaimer">
-          <span>
-            <Trans>Disclaimer</Trans>
-          </span>
+        <nav className="footer__legal-pages">
+          <a
+            href="privacy_policy"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="jfcl-link"
+          >
+            <Trans>Privacy Policy</Trans>
+          </a>
+          <a
+            href="terms_of_use"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="jfcl-link"
+          >
+            <Trans>Terms of Use</Trans>
+          </a>
+          <a
+            href="https://form.typeform.com/to/QUPQjBlI"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="jfcl-link"
+          >
+            <Trans>Feedback Form</Trans>
+          </a>
+        </nav>
+      </div>
+      <hr />
+      <div className="footer__bottom-bar">
+        <div className="footer__name">
+          <Link to={`/${i18n.locale}`} className="jfcl-link">
+            <Trans>Good Cause NYC</Trans>
+          </Link>
+        </div>
+        <div className="footer__collab">
           <Trans>
-            The information on this website does not constitute legal advice and
-            must not be used as a substitute for the advice of a lawyer
-            qualified to give advice on legal issues pertaining to housing.
+            By{" "}
+            <a
+              href="https://housingjusticeforall.org/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="jfcl-link"
+            >
+              Housing Justice for All
+            </a>{" "}
+            &{" "}
+            <a
+              href="https://justfix.org/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="jfcl-link"
+            >
+              JustFix
+            </a>
           </Trans>
         </div>
       </div>
-      <nav className="footer__legal-pages">
-        <a
-          href="privacy_policy"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="jfcl-link"
-        >
-          <Trans>Privacy Policy</Trans>
-        </a>
-        <a
-          href="terms_of_use"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="jfcl-link"
-        >
-          <Trans>Terms of Use</Trans>
-        </a>
-        <a
-          href="https://form.typeform.com/to/QUPQjBlI"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="jfcl-link"
-        >
-          <Trans>Feedback Form</Trans>
-        </a>
-      </nav>
-    </div>
-    <hr />
-    <div className="footer__bottom-bar">
-      <div className="footer__name">
-        <Link to="/" className="jfcl-link">
-          <Trans>Good Cause NYC</Trans>
-        </Link>
-      </div>
-      <div className="footer__collab">
-        <Trans>
-          By{" "}
-          <a
-            href="https://housingjusticeforall.org/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="jfcl-link"
-          >
-            Housing Justice for All
-          </a>{" "}
-          &{" "}
-          <a
-            href="https://justfix.org/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="jfcl-link"
-          >
-            JustFix
-          </a>
-        </Trans>
-      </div>
-    </div>
-  </footer>
-);
+    </footer>
+  );
+};

--- a/src/Components/Header/Header.tsx
+++ b/src/Components/Header/Header.tsx
@@ -5,6 +5,7 @@ import { BackLink } from "../JFCLLink";
 import { abbreviateBoro, ProgressStep, toTitleCase } from "../../helpers";
 import { gtmPush } from "../../google-tag-manager";
 import { Trans } from "@lingui/react/macro";
+import { useLingui } from "@lingui/react";
 
 type HeaderProps = {
   title: string | React.ReactNode;
@@ -25,13 +26,14 @@ export const Header: React.FC<HeaderProps> = ({
   lastStepReached,
   children,
 }) => {
+  const { i18n } = useLingui();
   return (
     <div className="headline-section">
       <div className="headline-section__content">
         {isGuide && (
           <nav className="headline-section__back-link">
             <BackLink
-              to="/results"
+              to={`/${i18n.locale}/results`}
               onClick={() => gtmPush("gce_back_to_result")}
             >
               <Trans>Back to Result</Trans>

--- a/src/Components/JFCLLink.tsx
+++ b/src/Components/JFCLLink.tsx
@@ -1,7 +1,9 @@
 import React from "react";
-import { Link, LinkProps } from "react-router-dom";
+import { Link, LinkProps, To } from "react-router-dom";
 import { Icon, IconNames } from "@justfixnyc/component-library";
 import classNames from "classnames";
+import { useLingui } from "@lingui/react";
+import { removeLocalePrefix } from "../i18n";
 
 // Creating versions of React Router's Link component styled like our Component
 // library's Link.
@@ -28,9 +30,29 @@ export const JFCLLink: React.FC<JFCLLinkProps> = ({
   </Link>
 );
 
+export const JFCLLocaleLink: React.FC<JFCLLinkProps> = (props) => {
+  const { i18n } = useLingui();
+
+  let to: To;
+  if (typeof props.to === "string") {
+    to = props.to.startsWith("/")
+      ? `/${i18n.locale}${removeLocalePrefix(props.to)}`
+      : props.to;
+  } else {
+    to = {
+      ...props.to,
+      pathname: props.to.pathname?.startsWith("/")
+        ? `/${i18n.locale}${removeLocalePrefix(props.to.pathname)}`
+        : props.to.pathname,
+    };
+  }
+
+  return <JFCLLink {...props} to={to} />;
+};
+
 export const JFCLLinkInternal: React.FC<Omit<JFCLLinkProps, "icon">> = (
   props
-) => <JFCLLink icon="arrowRight" {...props} />;
+) => <JFCLLocaleLink icon="arrowRight" {...props} />;
 
 export const JFCLLinkExternal: React.FC<Omit<JFCLLinkProps, "icon">> = (
   props

--- a/src/Components/KYRContent/KYRContent.tsx
+++ b/src/Components/KYRContent/KYRContent.tsx
@@ -861,7 +861,7 @@ export const UnknownProtections: React.FC<KYRContentBoxProps> = ({
   coverageResult,
   className,
 }) => {
-  const { _ } = useLingui();
+  const { _, i18n } = useLingui();
 
   const defaultSubtitle = _(
     msg`Whether or not you are covered by Good Cause, you still have important tenant rights`
@@ -884,7 +884,7 @@ export const UnknownProtections: React.FC<KYRContentBoxProps> = ({
             type of housing you live in.
           </Trans>
         </p>
-        <JFCLLinkInternal to="/tenant_rights">
+        <JFCLLinkInternal to={`/${i18n.locale}/tenant_rights`}>
           <Trans>Learn more about your rights</Trans>
         </JFCLLinkInternal>
       </ContentBoxItem>

--- a/src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx
+++ b/src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx
@@ -18,6 +18,7 @@ import { InfoBox } from "../../InfoBox/InfoBox";
 import "./ConfirmAddress.scss";
 
 export const ConfirmAddress: React.FC = () => {
+  const { i18n } = useLingui();
   const navigate = useNavigate();
   const { _ } = useLingui();
   const { address, user } = useLoaderData() as {
@@ -57,7 +58,7 @@ export const ConfirmAddress: React.FC = () => {
     } catch {
       rollbar.error("Cannot connect to tenant platform");
     }
-    navigate("/survey");
+    navigate(`/${i18n.locale}/survey`);
   };
 
   return (
@@ -81,7 +82,7 @@ export const ConfirmAddress: React.FC = () => {
                   this address.
                 </Trans>
               </span>
-              <Link to="/" className="jfcl-link">
+              <Link to={`/${i18n.locale}`} className="jfcl-link">
                 <Trans>Search new address</Trans>
               </Link>
             </InfoBox>
@@ -109,7 +110,7 @@ export const ConfirmAddress: React.FC = () => {
           </ContentBox>
 
           <div className="confirmation__buttons">
-            <BackLink to="/" className="confirmation__back">
+            <BackLink to={`/${i18n.locale}`} className="confirmation__back">
               <Trans>Back</Trans>
             </BackLink>
             <Button

--- a/src/Components/Pages/Form/Survey.tsx
+++ b/src/Components/Pages/Form/Survey.tsx
@@ -45,7 +45,7 @@ const initialFields: FormFields = {
 };
 
 export const Survey: React.FC = () => {
-  const { _ } = useLingui();
+  const { _, i18n } = useLingui();
   const { address, user } = useLoaderData() as {
     address: Address;
     user?: GCEUser;
@@ -107,7 +107,7 @@ export const Survey: React.FC = () => {
     } catch {
       rollbar.error("Cannot connect to tenant platform");
     }
-    navigate(`/results`);
+    navigate(`/${i18n.locale}/results`);
   };
 
   const handleRadioChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
@@ -355,7 +355,10 @@ export const Survey: React.FC = () => {
             )}
           </form>
           <div className="form__buttons">
-            <BackLink to="/confirm_address" className="survey__back">
+            <BackLink
+              to={`/${i18n.locale}/confirm_address`}
+              className="survey__back"
+            >
               <Trans>Back</Trans>
             </BackLink>
             <Button

--- a/src/Components/Pages/Home/Home.tsx
+++ b/src/Components/Pages/Home/Home.tsx
@@ -29,7 +29,7 @@ export type Address = {
 };
 
 export const Home: React.FC = () => {
-  const { _ } = useLingui();
+  const { _, i18n } = useLingui();
   const navigate = useNavigate();
   const [sessionUser, setUser] = useSessionStorage<GCEUser>("user");
   const [address, setAddress, removeAddress] =
@@ -70,7 +70,7 @@ export const Home: React.FC = () => {
 
     removeFormFields();
     setLastStepReached(ProgressStep.Address);
-    navigate("confirm_address");
+    navigate(`/${i18n.locale}/confirm_address`);
   };
 
   return (
@@ -110,7 +110,7 @@ export const Home: React.FC = () => {
               rent.{" "}
             </Trans>
             <JFCLLinkInternal
-              to="/rent_calculator"
+              to={`/${i18n.locale}/rent_calculator`}
               onClick={() =>
                 gtmPush("gce_rent_calculator", { from: "home-page" })
               }
@@ -148,7 +148,7 @@ export const Home: React.FC = () => {
                 stronger than those provided by Good Cause.
               </Trans>
             </p>
-            <JFCLLinkInternal to="/tenant_rights">
+            <JFCLLinkInternal to={`/${i18n.locale}/tenant_rights`}>
               <Trans>Learn more about tenant protections in NYC</Trans>
             </JFCLLinkInternal>
           </div>

--- a/src/Components/Pages/PortfolioSize/PortfolioSize.tsx
+++ b/src/Components/Pages/PortfolioSize/PortfolioSize.tsx
@@ -44,7 +44,7 @@ export const PortfolioSize: React.FC = () => {
     fields: FormFields;
   };
   const [, setSearchParams] = useSearchParams();
-  const { _ } = useLingui();
+  const { _, i18n } = useLingui();
 
   useAccordionsOpenForPrint();
   useSearchParamsURL(setSearchParams, address, fields, user);
@@ -275,7 +275,7 @@ export const PortfolioSize: React.FC = () => {
             <ContentBoxFooter
               message={_(msg`Have you learned something new?`)}
               linkText={_(msg`Adjust survey answers`)}
-              linkTo="/survey"
+              linkTo={`${i18n.locale}/survey`}
               linkOnClick={() =>
                 gtmPush("gce_return_survey", { from: "portfolio-guide-page" })
               }

--- a/src/Components/Pages/RentCalculator/RentCalculator.tsx
+++ b/src/Components/Pages/RentCalculator/RentCalculator.tsx
@@ -24,7 +24,7 @@ export const CPI = 3.79;
 const CPI_EFFECTIVE_DATE = msg`February 19, 2025`;
 
 export const RentCalculator: React.FC = () => {
-  const { _ } = useLingui();
+  const { _, i18n } = useLingui();
   useAccordionsOpenForPrint();
 
   const increase_pct = CPI + 5;
@@ -83,7 +83,7 @@ export const RentCalculator: React.FC = () => {
                 type="submit"
                 variant="primary"
                 size="small"
-                labelText="Calculate"
+                labelText={_(msg`Calculate`)}
               />
             </form>
             <div className="rent-increase-container">
@@ -140,7 +140,7 @@ export const RentCalculator: React.FC = () => {
             </strong>{" "}
             <p className="mobile-breakpoint"></p>
             <JFCLLinkInternal
-              to="/"
+              to={`/${i18n.locale}`}
               onClick={() =>
                 gtmPush("gce_return_survey", {
                   from: "rent-calculator-page",
@@ -166,7 +166,7 @@ export const RentCalculator: React.FC = () => {
             <ContentBoxFooter
               message={_(msg`Find out if you’re covered by Good Cause`)}
               linkText={_(msg`Take the survey`)}
-              linkTo="/"
+              linkTo={`/${i18n.locale}}`}
               linkOnClick={() =>
                 gtmPush("gce_return_survey", {
                   from: "rent-calculator-page",

--- a/src/Components/Pages/RentStabilization/RentStabilization.tsx
+++ b/src/Components/Pages/RentStabilization/RentStabilization.tsx
@@ -22,7 +22,7 @@ import { RentStabilizedProtections } from "../../KYRContent/KYRContent";
 import { RentStabLeaseModal } from "../../Modal/Modal";
 
 export const RentStabilization: React.FC = () => {
-  const { _ } = useLingui();
+  const { _, i18n } = useLingui();
   const { user, address, fields } = useLoaderData() as {
     user: GCEUser;
     address: Address;
@@ -142,7 +142,7 @@ export const RentStabilization: React.FC = () => {
             <ContentBoxFooter
               message={_(msg`Update your coverage result`)}
               linkText={_(msg`Adjust survey answers`)}
-              linkTo="/survey"
+              linkTo={`${i18n.locale}/survey`}
               linkOnClick={() =>
                 gtmPush("gce_return_survey", {
                   from: "rent-stab-guide-page",

--- a/src/Components/Pages/Results/Results.tsx
+++ b/src/Components/Pages/Results/Results.tsx
@@ -369,50 +369,57 @@ const CriterionRow: React.FC<CriterionDetails> = (props) => {
 
 const CriteriaTable: React.FC<{
   criteria?: CriteriaDetails;
-}> = ({ criteria }) => (
-  <ContentBox className="criteria-table">
-    <div className="criteria-table__header">
-      <span className="criteria-table__header__title">
-        <Trans>How we determined your coverage</Trans>
-      </span>
-      <p>
-        <Trans>
-          Results are based on publicly available data about your building and
-          the answers you provided. This does not constitute legal advice.
-        </Trans>
-      </p>
-    </div>
-    <ul className="criteria-table__list">
-      {criteria?.rent && <CriterionRow {...criteria.rent} />}
-      {criteria?.rentStabilized && (
-        <CriterionRow {...criteria.rentStabilized} />
-      )}
-      {criteria?.buildingClass && <CriterionRow {...criteria.buildingClass} />}
-      {criteria?.certificateOfOccupancy && (
-        <CriterionRow {...criteria.certificateOfOccupancy} />
-      )}
-      {criteria?.subsidy && <CriterionRow {...criteria.subsidy} />}
-      {criteria?.landlord && <CriterionRow {...criteria.landlord} />}
-      {criteria?.portfolioSize && <CriterionRow {...criteria.portfolioSize} />}
-    </ul>
-    <ContentBoxFooter
-      message="Need to update your information?"
-      linkText="Back to survey"
-      linkTo="/survey"
-      linkOnClick={() =>
-        gtmPush("gce_return_survey", { from: "results-page_criteria-table" })
-      }
-      className="criteria-table__footer"
-    />
-  </ContentBox>
-);
+}> = ({ criteria }) => {
+  const { _, i18n } = useLingui();
+  return (
+    <ContentBox className="criteria-table">
+      <div className="criteria-table__header">
+        <span className="criteria-table__header__title">
+          <Trans>How we determined your coverage</Trans>
+        </span>
+        <p>
+          <Trans>
+            Results are based on publicly available data about your building and
+            the answers you provided. This does not constitute legal advice.
+          </Trans>
+        </p>
+      </div>
+      <ul className="criteria-table__list">
+        {criteria?.rent && <CriterionRow {...criteria.rent} />}
+        {criteria?.rentStabilized && (
+          <CriterionRow {...criteria.rentStabilized} />
+        )}
+        {criteria?.buildingClass && (
+          <CriterionRow {...criteria.buildingClass} />
+        )}
+        {criteria?.certificateOfOccupancy && (
+          <CriterionRow {...criteria.certificateOfOccupancy} />
+        )}
+        {criteria?.subsidy && <CriterionRow {...criteria.subsidy} />}
+        {criteria?.landlord && <CriterionRow {...criteria.landlord} />}
+        {criteria?.portfolioSize && (
+          <CriterionRow {...criteria.portfolioSize} />
+        )}
+      </ul>
+      <ContentBoxFooter
+        message={_(msg`Need to update your information?`)}
+        linkText={_(msg`Back to survey`)}
+        linkTo={`/${i18n.locale}/survey`}
+        linkOnClick={() =>
+          gtmPush("gce_return_survey", { from: "results-page_criteria-table" })
+        }
+        className="criteria-table__footer"
+      />
+    </ContentBox>
+  );
+};
 
 const EligibilityNextSteps: React.FC<{
   bldgData: BuildingData;
   criteriaDetails: CriteriaDetails;
   searchParams: URLSearchParams;
 }> = ({ bldgData, criteriaDetails, searchParams }) => {
-  const { _ } = useLingui();
+  const { _, i18n } = useLingui();
   const rentStabilizedUnknown =
     criteriaDetails?.rentStabilized?.determination === "UNKNOWN";
   const portfolioSizeUnknown =
@@ -455,7 +462,9 @@ const EligibilityNextSteps: React.FC<{
               </Trans>
             </p>
             <JFCLLinkInternal
-              to={`/rent_stabilization?${searchParams.toString()}`}
+              to={`/${
+                i18n.locale
+              }/rent_stabilization?${searchParams.toString()}`}
             >
               <Trans>Find out if your apartment is rent stabilized</Trans>
             </JFCLLinkInternal>
@@ -479,7 +488,9 @@ const EligibilityNextSteps: React.FC<{
                 buildings.
               </Trans>
             </p>
-            <JFCLLinkInternal to={`/portfolio_size?${searchParams.toString()}`}>
+            <JFCLLinkInternal
+              to={`/${i18n.locale}/portfolio_size?${searchParams.toString()}`}
+            >
               <Trans>Find other buildings your landlord owns</Trans>
             </JFCLLinkInternal>
           </ContentBoxItem>
@@ -488,7 +499,7 @@ const EligibilityNextSteps: React.FC<{
         <ContentBoxFooter
           message={_(msg`Have you learned something new?`)}
           linkText={_(msg`Adjust survey answers`)}
-          linkTo="/survey"
+          linkTo={`${i18n.locale}/survey`}
           linkOnClick={() =>
             gtmPush("gce_return_survey", { from: "results-page_next-steps" })
           }

--- a/src/Components/Pages/TenantRights/TenantRights.tsx
+++ b/src/Components/Pages/TenantRights/TenantRights.tsx
@@ -13,7 +13,7 @@ import { useAccordionsOpenForPrint } from "../../../hooks/useAccordionsOpenForPr
 import "./TenantRights.scss";
 
 export const TenantRights: React.FC = () => {
-  const { _ } = useLingui();
+  const { _, i18n } = useLingui();
 
   useAccordionsOpenForPrint();
 
@@ -35,7 +35,7 @@ export const TenantRights: React.FC = () => {
             <ContentBoxFooter
               message={_(msg`Find out if you’re covered by Good Cause`)}
               linkText={_(msg`Take the survey`)}
-              linkTo="/"
+              linkTo={`/${i18n.locale}`}
             />
           </GoodCauseProtections>
 
@@ -43,7 +43,7 @@ export const TenantRights: React.FC = () => {
             <ContentBoxFooter
               message={_(msg`Find out if your apartment is rent stabilized`)}
               linkText={_(msg`View the guide`)}
-              linkTo="/rent_stabilization"
+              linkTo={`/${i18n.locale}/rent_stabilization`}
             />
           </RentStabilizedProtections>
 

--- a/src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx
+++ b/src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx
@@ -99,12 +99,11 @@ const PhoneNumberCapture: React.FC<PhoneNumberCaptureProps> = (props) => {
     }
     try {
       const sendData = async () => {
-        const resultUrlParam =
-          window.location.pathname === "/results"
-            ? {
-                result_url: window.location.href,
-              }
-            : {};
+        const resultUrlParam = window.location.pathname.includes("/results")
+          ? {
+              result_url: window.location.href,
+            }
+          : {};
         const postData = {
           id: user?.id,
           phone_number: parseInt(cleaned),

--- a/src/Components/ProgressBar/ProgressBar.tsx
+++ b/src/Components/ProgressBar/ProgressBar.tsx
@@ -18,14 +18,14 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
   lastStepReached = ProgressStep.Home,
 }) => {
   const location = useLocation();
-  const { _ } = useLingui();
+  const { _, i18n } = useLingui();
   const steps: StepInfo[] = [
     {
-      path: "/confirm_address",
+      path: `/${i18n.locale}/confirm_address`,
       name: progressBarAddress(lastStepReached, address) || _(msg`Address`),
     },
-    { path: "/survey", name: _(msg`Survey`) },
-    { path: "/results", name: _(msg`Result`) },
+    { path: `/${i18n.locale}/survey`, name: _(msg`Survey`) },
+    { path: `/${i18n.locale}/results`, name: _(msg`Result`) },
   ].map((step) => {
     return { ...step, active: step.path == location.pathname };
   });
@@ -35,7 +35,7 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
       step.active || index > lastStepReached ? (
         <span>{step.name}</span>
       ) : (
-        <Link to={step.path ?? "/"} className="jfcl-link">
+        <Link to={step.path ?? `/${i18n.locale}`} className="jfcl-link">
           {step.name}
         </Link>
       );

--- a/src/Components/TopBar/TopBar.tsx
+++ b/src/Components/TopBar/TopBar.tsx
@@ -8,8 +8,10 @@ import { useScrollDirection } from "../../hooks/useScrollDirection";
 import useInViewPort from "../../hooks/useInViewport";
 import { JFCLLinkInternal } from "../JFCLLink";
 import "./TopBar.scss";
+import { useLingui } from "@lingui/react";
 
 export const TopBar: React.FC = () => {
+  const { i18n } = useLingui();
   const isScrollingUp = useScrollDirection() === "up";
   const placeholderRef = useRef<HTMLDivElement | null>(null);
   const placeholderInViewport = useInViewPort(placeholderRef);
@@ -20,7 +22,7 @@ export const TopBar: React.FC = () => {
       <header id="topbar" className={classNames(hideTopbar && "hide")}>
         <div className="topbar__name">
           <h1>
-            <Link to="/">
+            <Link to={`/${i18n.locale}`}>
               <Trans>Good Cause NYC</Trans>
             </Link>
           </h1>
@@ -47,7 +49,7 @@ export const TopBar: React.FC = () => {
         </div>
         <div className="topbar__rent-calculator">
           <JFCLLinkInternal
-            to="/rent_calculator"
+            to={`/${i18n.locale}/rent_calculator`}
             onClick={() => gtmPush("gce_rent_calculator", { from: "navbar" })}
           >
             <Trans>Rent increase calculator</Trans>

--- a/src/hooks/useCriteriaResults.tsx
+++ b/src/hooks/useCriteriaResults.tsx
@@ -1,5 +1,5 @@
 import { Plural, Trans } from "@lingui/react/macro";
-
+import { I18n } from "@lingui/core";
 import { JFCLLinkExternal, JFCLLinkInternal } from "../Components/JFCLLink";
 import {
   BuildingSubsidyLanguage,
@@ -16,6 +16,7 @@ import {
   urlWOWTimelineRS,
   urlZOLA,
 } from "../helpers";
+import { useLingui } from "@lingui/react";
 
 // These values need to be updated annually. They are published by DHCR on or before August 1 each year
 const RENT_CUTOFFS = {
@@ -59,14 +60,15 @@ export function useCriteriaResults(
   searchParams: URLSearchParams,
   bldgData?: BuildingData
 ): CriteriaDetails | undefined {
+  const { i18n } = useLingui();
   if (!bldgData) return undefined;
   const criteriaData: CriteriaData = { ...formFields, ...bldgData };
   return {
-    portfolioSize: eligibilityPortfolioSize(criteriaData, searchParams),
+    portfolioSize: eligibilityPortfolioSize(criteriaData, searchParams, i18n),
     landlord: eligibilityLandlord(criteriaData),
     buildingClass: eligibilityBuildingClass(criteriaData),
     rent: eligibilityRent(criteriaData),
-    rentStabilized: eligibilityRentStabilized(criteriaData, searchParams),
+    rentStabilized: eligibilityRentStabilized(criteriaData, searchParams, i18n),
     certificateOfOccupancy: eligibilityCertificateOfOccupancy(criteriaData),
     subsidy: eligibilitySubsidy(criteriaData),
   };
@@ -74,7 +76,8 @@ export function useCriteriaResults(
 
 function eligibilityPortfolioSize(
   criteriaData: CriteriaData,
-  searchParams: URLSearchParams
+  searchParams: URLSearchParams,
+  i18n: I18n
 ): CriterionDetails {
   const {
     bbl,
@@ -154,8 +157,8 @@ function eligibilityPortfolioSize(
   } else {
     determination = "UNKNOWN";
     userValue = (
-      <Trans>
-        Your building has only {pluralApartments}, but
+      <>
+        <Trans>Your building has only {pluralApartments}, but</Trans>
         {relatedProperties ? (
           <Trans>
             publicly available data sources indicate that your landlord may be
@@ -164,11 +167,13 @@ function eligibilityPortfolioSize(
         ) : (
           <Trans>your landlord may own</Trans>
         )}{" "}
-        other buildings.{" "}
-        <JFCLLinkInternal to={`/portfolio_size?${searchParams.toString()}`}>
-          Find your landlord’s other buildings
+        <Trans>other buildings.</Trans>{" "}
+        <JFCLLinkInternal
+          to={`/${i18n.locale}/portfolio_size?${searchParams.toString()}`}
+        >
+          <Trans>Find your landlord’s other buildings</Trans>
         </JFCLLinkInternal>
-      </Trans>
+      </>
     );
   }
 
@@ -288,7 +293,8 @@ function eligibilityRent(criteriaData: CriteriaData): CriterionDetails {
 
 function eligibilityRentStabilized(
   criteriaData: CriteriaData,
-  searchParams: URLSearchParams
+  searchParams: URLSearchParams,
+  i18n: I18n
 ): CriterionDetails {
   const {
     rentStabilized,
@@ -317,7 +323,9 @@ function eligibilityRentStabilized(
     </JFCLLinkExternal>
   );
   const guideLink = (
-    <JFCLLinkInternal to={`/rent_stabilization?${searchParams.toString()}`}>
+    <JFCLLinkInternal
+      to={`/${i18n.locale}/rent_stabilization?${searchParams.toString()}`}
+    >
       <Trans>Find out if your apartment is rent stabilized</Trans>
     </JFCLLinkInternal>
   );

--- a/src/i18n.tsx
+++ b/src/i18n.tsx
@@ -111,9 +111,9 @@ export function I18n({ children }: { children: React.ReactNode }): JSX.Element {
  * without the locale prefix (e.g. `/boop`).
  */
 export function removeLocalePrefix(path: string): string {
-  const pathParts = path.split("/");
-  pathParts.splice(1, 1);
-  return pathParts.join("/");
+  const match = path.match(/^\/([a-z]{2})\/(.*)$/);
+  if (!match || !isSupportedLocale(match[1])) return path;
+  return `/${match[2]}`;
 }
 
 /**

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -26,8 +26,8 @@ msgstr ""
 #~ msgid "\"How to find out if your apartment is rent stabilized"
 #~ msgstr "\"How to find out if your apartment is rent stabilized"
 
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:166
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:245
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:165
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:244
 msgid "(123) 456-7890"
 msgstr "(123) 456-7890"
 
@@ -41,7 +41,7 @@ msgstr "(Your current monthly rent {0} + {increase_pct}%)"
 msgid "{0} "
 msgstr "{0} "
 
-#: src/hooks/useCriteriaResults.tsx:258
+#: src/hooks/useCriteriaResults.tsx:263
 msgid "{bedrooms} bedroom"
 msgstr "{bedrooms} bedroom"
 
@@ -50,7 +50,7 @@ msgid "{docType}"
 msgstr "{docType}"
 
 #: src/Components/Pages/PortfolioSize/PortfolioSize.tsx:337
-#: src/hooks/useCriteriaResults.tsx:104
+#: src/hooks/useCriteriaResults.tsx:107
 msgid "{unitsres, plural, one {# apartment} other {# apartments}}"
 msgstr "{unitsres, plural, one {# apartment} other {# apartments}}"
 
@@ -78,27 +78,27 @@ msgstr "<0>Tip:</0> If, in any one of the documents below, you find an owner’s
 msgid "<0>Tip:</0> We recommend doing the following research on a desktop computer. If you have not already, please watch the video, above, for step-by-step instructions on how to complete Steps 1 and 2."
 msgstr "<0>Tip:</0> We recommend doing the following research on a desktop computer. If you have not already, please watch the video, above, for step-by-step instructions on how to complete Steps 1 and 2."
 
-#: src/Components/Pages/Results/Results.tsx:570
+#: src/Components/Pages/Results/Results.tsx:574
 msgid "<0>You are</0> <1>likely covered</1> by Good Cause Eviction"
 msgstr "<0>You are</0> <1>likely covered</1> by Good Cause Eviction"
 
-#: src/Components/Pages/Results/Results.tsx:551
+#: src/Components/Pages/Results/Results.tsx:555
 msgid "<0>You are</0> <1>likely not covered</1> <2/>by Good Cause Eviction"
 msgstr "<0>You are</0> <1>likely not covered</1> <2/>by Good Cause Eviction"
 
-#: src/Components/Pages/Results/Results.tsx:542
+#: src/Components/Pages/Results/Results.tsx:546
 msgid "<0>You</0> <1>might be covered</1> by Good Cause Eviction"
 msgstr "<0>You</0> <1>might be covered</1> by Good Cause Eviction"
 
-#: src/Components/Pages/Results/Results.tsx:579
+#: src/Components/Pages/Results/Results.tsx:583
 msgid "<0>Your apartment is part of</0> <1>NYCHA or PACT/RAD</1> which provides stronger protections than Good Cause Eviction"
 msgstr "<0>Your apartment is part of</0> <1>NYCHA or PACT/RAD</1> which provides stronger protections than Good Cause Eviction"
 
-#: src/Components/Pages/Results/Results.tsx:561
+#: src/Components/Pages/Results/Results.tsx:565
 msgid "<0>Your apartment is</0> <1>rent stabilized</1> which provides stronger protections than Good Cause Eviction"
 msgstr "<0>Your apartment is</0> <1>rent stabilized</1> which provides stronger protections than Good Cause Eviction"
 
-#: src/Components/Pages/Results/Results.tsx:590
+#: src/Components/Pages/Results/Results.tsx:594
 msgid "<0>Your building is</0> <1>subsidized</1> which provides existing eviction protections"
 msgstr "<0>Your building is</0> <1>subsidized</1> which provides existing eviction protections"
 
@@ -142,11 +142,11 @@ msgstr "5. Does your landlord live in the building?"
 msgid "6. Does your landlord own more than 10 apartments across multiple buildings?"
 msgstr "6. Does your landlord own more than 10 apartments across multiple buildings?"
 
-#: src/hooks/useCriteriaResults.tsx:408
+#: src/hooks/useCriteriaResults.tsx:416
 msgid "a co-op"
 msgstr "a co-op"
 
-#: src/hooks/useCriteriaResults.tsx:405
+#: src/hooks/useCriteriaResults.tsx:413
 msgid "a condo"
 msgstr "a condo"
 
@@ -176,7 +176,7 @@ msgstr "Address"
 
 #: src/Components/Pages/PortfolioSize/PortfolioSize.tsx:277
 #: src/Components/Pages/RentStabilization/RentStabilization.tsx:144
-#: src/Components/Pages/Results/Results.tsx:497
+#: src/Components/Pages/Results/Results.tsx:501
 msgid "Adjust survey answers"
 msgstr "Adjust survey answers"
 
@@ -184,7 +184,7 @@ msgstr "Adjust survey answers"
 msgid "Agreement"
 msgstr "Agreement"
 
-#: src/hooks/useCriteriaResults.tsx:353
+#: src/hooks/useCriteriaResults.tsx:361
 msgid "all apartments in your building are registered as rent stabilized."
 msgstr "all apartments in your building are registered as rent stabilized."
 
@@ -210,11 +210,11 @@ msgid "Attend a walk-in Clinic hosted by the Met Council on Housing"
 msgstr "Attend a walk-in Clinic hosted by the Met Council on Housing"
 
 #: src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx:114
-#: src/Components/Pages/Form/Survey.tsx:359
+#: src/Components/Pages/Form/Survey.tsx:362
 msgid "Back"
 msgstr "Back"
 
-#: src/Components/Header/Header.tsx:37
+#: src/Components/Header/Header.tsx:39
 msgid "Back to Result"
 msgstr "Back to Result"
 
@@ -230,15 +230,15 @@ msgstr "Based on data from the website {wowLink}, we gather a list of properties
 msgid "Based on data from the website {wowLink}, we have gathered a list of properties that the owner of your building may be associated with. For each property, we have included links to important real estate transaction documents."
 msgstr "Based on data from the website {wowLink}, we have gathered a list of properties that the owner of your building may be associated with. For each property, we have included links to important real estate transaction documents."
 
-#: src/Components/Pages/Form/Survey.tsx:541
+#: src/Components/Pages/Form/Survey.tsx:544
 msgid "Because your building has fewer than 6 units and was built after 1974, it is very unlikely that your apartment is rent stabilized. Additionally, based on publicly available data, no rent stabilized apartments were registered in your building in recent years."
 msgstr "Because your building has fewer than 6 units and was built after 1974, it is very unlikely that your apartment is rent stabilized. Additionally, based on publicly available data, no rent stabilized apartments were registered in your building in recent years."
 
-#: src/Components/Pages/Form/Survey.tsx:564
+#: src/Components/Pages/Form/Survey.tsx:567
 msgid "Because your building has fewer than 6 units it is very unlikely that your apartment is rent stabilized. Additionally, based on publicly available, no rent stabilized apartments were registered in your building in recent years."
 msgstr "Because your building has fewer than 6 units it is very unlikely that your apartment is rent stabilized. Additionally, based on publicly available, no rent stabilized apartments were registered in your building in recent years."
 
-#: src/Components/Pages/Form/Survey.tsx:552
+#: src/Components/Pages/Form/Survey.tsx:555
 msgid "Because your building was built after 1974 and is not part of 421a or J51 tax incentive programs, it is very unlikely that your apartment is rent stabilized. Additionally, based on publicly available, no rent stabilized apartments were registered in your building in recent years."
 msgstr "Because your building was built after 1974 and is not part of 421a or J51 tax incentive programs, it is very unlikely that your apartment is rent stabilized. Additionally, based on publicly available, no rent stabilized apartments were registered in your building in recent years."
 
@@ -279,23 +279,23 @@ msgstr "Check your most recent lease renewal"
 msgid "City data indicates that there aren’t any residential units at this address."
 msgstr "City data indicates that there aren’t any residential units at this address."
 
-#: src/hooks/useCriteriaResults.tsx:420
+#: src/hooks/useCriteriaResults.tsx:428
 msgid "classified as a health facility"
 msgstr "classified as a health facility"
 
-#: src/hooks/useCriteriaResults.tsx:414
+#: src/hooks/useCriteriaResults.tsx:422
 msgid "classified as a hotel"
 msgstr "classified as a hotel"
 
-#: src/hooks/useCriteriaResults.tsx:417
+#: src/hooks/useCriteriaResults.tsx:425
 msgid "classified as a religious facility"
 msgstr "classified as a religious facility"
 
-#: src/hooks/useCriteriaResults.tsx:411
+#: src/hooks/useCriteriaResults.tsx:419
 msgid "classified as an educational building"
 msgstr "classified as an educational building"
 
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:276
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:275
 msgid "Close"
 msgstr "Close"
 
@@ -307,11 +307,11 @@ msgstr "Close modal"
 msgid "Confirm"
 msgstr "Confirm"
 
-#: src/Components/Pages/Results/Results.tsx:631
+#: src/Components/Pages/Results/Results.tsx:635
 msgid "Copied"
 msgstr "Copied"
 
-#: src/Components/Pages/Results/Results.tsx:623
+#: src/Components/Pages/Results/Results.tsx:627
 msgid "Copy goodcausenyc.org"
 msgstr "Copy goodcausenyc.org"
 
@@ -341,8 +341,8 @@ msgstr "Eligible"
 msgid "Email coverage"
 msgstr "Email coverage"
 
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:168
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:247
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:167
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:246
 msgid "Enter a valid phone number"
 msgstr "Enter a valid phone number"
 
@@ -378,7 +378,7 @@ msgstr "Failure to sign lease renewal or provide access to apartment"
 msgid "Fair Housing NYC"
 msgstr "Fair Housing NYC"
 
-#: src/Components/Pages/Form/Survey.tsx:380
+#: src/Components/Pages/Form/Survey.tsx:383
 msgid "FAQs to help guide your answer"
 msgstr "FAQs to help guide your answer"
 
@@ -394,7 +394,7 @@ msgstr "Feedback Form"
 msgid "Fill out the request form"
 msgstr "Fill out the request form"
 
-#: src/Components/Pages/Results/Results.tsx:490
+#: src/Components/Pages/Results/Results.tsx:494
 msgid "Find other buildings your landlord owns"
 msgstr "Find other buildings your landlord owns"
 
@@ -409,9 +409,9 @@ msgid "Find out if you’re covered by Good Cause"
 msgstr "Find out if you’re covered by Good Cause"
 
 #: src/Components/Pages/RentStabilization/RentStabilization.tsx:42
-#: src/Components/Pages/Results/Results.tsx:467
+#: src/Components/Pages/Results/Results.tsx:469
 #: src/Components/Pages/TenantRights/TenantRights.tsx:44
-#: src/hooks/useCriteriaResults.tsx:321
+#: src/hooks/useCriteriaResults.tsx:329
 msgid "Find out if your apartment is rent stabilized"
 msgstr "Find out if your apartment is rent stabilized"
 
@@ -419,13 +419,13 @@ msgstr "Find out if your apartment is rent stabilized"
 msgid "Find out if your landlord owns other buildings"
 msgstr "Find out if your landlord owns other buildings"
 
-#: src/hooks/useCriteriaResults.tsx:169
+#: src/hooks/useCriteriaResults.tsx:174
 msgid "Find your landlord’s other buildings"
 msgstr "Find your landlord’s other buildings"
 
 #. placeholder {0}: bedrooms === "STUDIO" ? ( <Trans>studio</Trans> ) : ( <Trans>{bedrooms} bedroom</Trans> )
 #. placeholder {1}: formatMoney(RENT_CUTOFFS[bedrooms], 0)
-#: src/hooks/useCriteriaResults.tsx:253
+#: src/hooks/useCriteriaResults.tsx:258
 msgid "For a {0}, the monthly total rent must be less than {1}"
 msgstr "For a {0}, the monthly total rent must be less than {1}"
 
@@ -450,7 +450,7 @@ msgid "Get started"
 msgstr "Get started"
 
 #. placeholder {0}: bldgData.unitsres
-#: src/Components/Pages/Results/Results.tsx:482
+#: src/Components/Pages/Results/Results.tsx:484
 msgid "Good Cause Eviction law only covers tenants whose landlord owns more than 10 apartments. Your building has only {0} apartments, but your landlord may own other buildings."
 msgstr "Good Cause Eviction law only covers tenants whose landlord owns more than 10 apartments. Your building has only {0} apartments, but your landlord may own other buildings."
 
@@ -484,7 +484,7 @@ msgid "Has your landlord raised your rent? Is your landlord refusing to do basic
 msgstr "Has your landlord raised your rent? Is your landlord refusing to do basic repairs? Are you worried about getting evicted or non-renewed?"
 
 #: src/Components/Pages/PortfolioSize/PortfolioSize.tsx:276
-#: src/Components/Pages/Results/Results.tsx:496
+#: src/Components/Pages/Results/Results.tsx:500
 msgid "Have you learned something new?"
 msgstr "Have you learned something new?"
 
@@ -538,19 +538,19 @@ msgstr "How we determined your coverage"
 msgid "I'm not sure"
 msgstr "I'm not sure"
 
-#: src/hooks/useCriteriaResults.tsx:188
+#: src/hooks/useCriteriaResults.tsx:193
 msgid "If the building has 10 or fewer apartments, the landlord must not also live in it."
 msgstr "If the building has 10 or fewer apartments, the landlord must not also live in it."
 
-#: src/hooks/useCriteriaResults.tsx:585
+#: src/hooks/useCriteriaResults.tsx:593
 msgid "If those sources are correct, then you may already have stronger tenant protections than other subsidized housing programs."
 msgstr "If those sources are correct, then you may already have stronger tenant protections than other subsidized housing programs."
 
-#: src/hooks/useCriteriaResults.tsx:608
+#: src/hooks/useCriteriaResults.tsx:616
 msgid "If those sources are correct, you may have existing tenant protections through NYCHA or PACT/RAD."
 msgstr "If those sources are correct, you may have existing tenant protections through NYCHA or PACT/RAD."
 
-#: src/hooks/useCriteriaResults.tsx:665
+#: src/hooks/useCriteriaResults.tsx:673
 msgid "If those sources are correct, you may have existing tenant protections through your building’s subsidy program."
 msgstr "If those sources are correct, you may have existing tenant protections through your building’s subsidy program."
 
@@ -558,7 +558,7 @@ msgstr "If those sources are correct, you may have existing tenant protections t
 #~ msgid "If you applied for your apartment through \"NYC Housing Connect,\" your building is very likely subsidized, and you should select the option: <0>\"Other subsidized housing\"</0>"
 #~ msgstr "If you applied for your apartment through \"NYC Housing Connect,\" your building is very likely subsidized, and you should select the option: <0>\"Other subsidized housing\"</0>"
 
-#: src/Components/Pages/Form/Survey.tsx:398
+#: src/Components/Pages/Form/Survey.tsx:401
 msgid "If you applied for your apartment through \"NYC Housing Connect,\" your building is very likely subsidized, and you should select the option: <0>“Yes, Mitchell-Lama, HDFC, or other”</0>"
 msgstr "If you applied for your apartment through \"NYC Housing Connect,\" your building is very likely subsidized, and you should select the option: <0>“Yes, Mitchell-Lama, HDFC, or other”</0>"
 
@@ -583,11 +583,11 @@ msgstr "If you are the immediate family member of a rent-stabilized tenant and h
 #~ msgid "If you know that your building is part of Low-Income Housing Tax Credit (LIHTC) program, select the option: <0>\"Other subsidized housing\"</0>"
 #~ msgstr "If you know that your building is part of Low-Income Housing Tax Credit (LIHTC) program, select the option: <0>\"Other subsidized housing\"</0>"
 
-#: src/Components/Pages/Form/Survey.tsx:407
+#: src/Components/Pages/Form/Survey.tsx:410
 msgid "If you know that your building is part of Low-Income Housing Tax Credit (LIHTC) program, select the option: <0>“Yes, Mitchell-Lama, HDFC, or other”</0> "
 msgstr "If you know that your building is part of Low-Income Housing Tax Credit (LIHTC) program, select the option: <0>“Yes, Mitchell-Lama, HDFC, or other”</0> "
 
-#: src/Components/Pages/Form/Survey.tsx:416
+#: src/Components/Pages/Form/Survey.tsx:419
 msgid "If you know that your building is part of public housing (NYCHA or PACT-RAD), select: <0>\"NYCHA or PACT/RAD\"</0>"
 msgstr "If you know that your building is part of public housing (NYCHA or PACT-RAD), select: <0>\"NYCHA or PACT/RAD\"</0>"
 
@@ -595,7 +595,7 @@ msgstr "If you know that your building is part of public housing (NYCHA or PACT-
 #~ msgid "If you know that your building receives 421a or J51 tax abatement, select the option: <0>\"None of the above\"</0>"
 #~ msgstr "If you know that your building receives 421a or J51 tax abatement, select the option: <0>\"None of the above\"</0>"
 
-#: src/Components/Pages/Form/Survey.tsx:424
+#: src/Components/Pages/Form/Survey.tsx:427
 msgid "If you know that your building receives 421a or J51 tax abatement, select the option:<0>“No, my building is not subsidized”</0>"
 msgstr "If you know that your building receives 421a or J51 tax abatement, select the option:<0>“No, my building is not subsidized”</0>"
 
@@ -611,7 +611,7 @@ msgstr "If you live in NYC and are not covered by Good Cause Eviction, you still
 msgid "If you live outside of NYC"
 msgstr "If you live outside of NYC"
 
-#: src/Components/Pages/Form/Survey.tsx:441
+#: src/Components/Pages/Form/Survey.tsx:444
 msgid "If you use a voucher that covers some or all of your rent, and you can use that voucher in another apartment if you move, select the option: <0>“No, my building is not subsidized”</0>"
 msgstr "If you use a voucher that covers some or all of your rent, and you can use that voucher in another apartment if you move, select the option: <0>“No, my building is not subsidized”</0>"
 
@@ -647,7 +647,7 @@ msgstr "If your landlord refuses to renew your lease, tells you that you have to
 msgid "If your landlord takes you to court, you can raise a “Good Cause” defense. Your landlord would then have to demonstrate to the judge that they raised the rent because of increased costs (taxes, maintenance costs, etc.) or be forced to lower the increase."
 msgstr "If your landlord takes you to court, you can raise a “Good Cause” defense. Your landlord would then have to demonstrate to the judge that they raised the rent because of increased costs (taxes, maintenance costs, etc.) or be forced to lower the increase."
 
-#: src/Components/Pages/Form/Survey.tsx:478
+#: src/Components/Pages/Form/Survey.tsx:481
 #: src/Components/Pages/RentStabilization/RentStabilization.tsx:107
 msgid "If your most recent lease renewal <0>looks like this</0>, then your apartment is likely rent stabilized."
 msgstr "If your most recent lease renewal <0>looks like this</0>, then your apartment is likely rent stabilized."
@@ -691,19 +691,19 @@ msgstr "Ineligible"
 msgid "Invoke “Good Cause” to a judge"
 msgstr "Invoke “Good Cause” to a judge"
 
-#: src/Components/Pages/Form/Survey.tsx:657
+#: src/Components/Pages/Form/Survey.tsx:660
 msgid "is a Mitchell-Lama"
 msgstr "is a Mitchell-Lama"
 
-#: src/Components/Pages/Form/Survey.tsx:653
+#: src/Components/Pages/Form/Survey.tsx:656
 msgid "is an Article XI"
 msgstr "is an Article XI"
 
-#: src/Components/Pages/Form/Survey.tsx:655
+#: src/Components/Pages/Form/Survey.tsx:658
 msgid "is part of an HPD subsidy program"
 msgstr "is part of an HPD subsidy program"
 
-#: src/Components/Pages/Form/Survey.tsx:659
+#: src/Components/Pages/Form/Survey.tsx:662
 msgid "is part of NYCHA or PACT/RAD"
 msgstr "is part of NYCHA or PACT/RAD"
 
@@ -768,7 +768,7 @@ msgstr "Learn how tenant associations can help"
 msgid "Learn if you’re covered <0/>by Good Cause <1/>Eviction law in NYC"
 msgstr "Learn if you’re covered <0/>by Good Cause <1/>Eviction law in NYC"
 
-#: src/Components/Pages/Form/Survey.tsx:600
+#: src/Components/Pages/Form/Survey.tsx:603
 msgid "Learn more"
 msgstr "Learn more"
 
@@ -866,7 +866,7 @@ msgstr "Loading document links..."
 msgid "Loading your results..."
 msgstr "Loading your results..."
 
-#: src/hooks/useCriteriaResults.tsx:399
+#: src/hooks/useCriteriaResults.tsx:407
 msgid "manufactured housing"
 msgstr "manufactured housing"
 
@@ -907,7 +907,7 @@ msgstr "Met Council on Housing’s Hotline"
 msgid "Met Council on Housing’s Rent Stabilization overview"
 msgstr "Met Council on Housing’s Rent Stabilization overview"
 
-#: src/hooks/useCriteriaResults.tsx:402
+#: src/hooks/useCriteriaResults.tsx:410
 msgid "missing class information"
 msgstr "missing class information"
 
@@ -929,12 +929,12 @@ msgstr "Need to update your information?"
 msgid "No"
 msgstr "No"
 
-#: src/hooks/useCriteriaResults.tsx:110
-#: src/hooks/useCriteriaResults.tsx:199
+#: src/hooks/useCriteriaResults.tsx:113
+#: src/hooks/useCriteriaResults.tsx:204
 msgid "No data available for the number of apartments in your building."
 msgstr "No data available for the number of apartments in your building."
 
-#: src/Components/Pages/Form/Survey.tsx:529
+#: src/Components/Pages/Form/Survey.tsx:532
 msgid "No rent stabilized apartments were registered in your building in recent years, but based on the size and age of your building some of the apartments may still be rent stabilized."
 msgstr "No rent stabilized apartments were registered in your building in recent years, but based on the size and age of your building some of the apartments may still be rent stabilized."
 
@@ -954,7 +954,7 @@ msgstr "Non payment of rent"
 msgid "Note"
 msgstr "Note"
 
-#: src/Components/Pages/Form/Survey.tsx:432
+#: src/Components/Pages/Form/Survey.tsx:435
 msgid "Note: if your building is part of 421a or J51, your apartment should be rent stabilized"
 msgstr "Note: if your building is part of 421a or J51, your apartment should be rent stabilized"
 
@@ -974,12 +974,12 @@ msgstr "NY Courts Warranty of Habitability fact sheet"
 msgid "NY Homes and Community Renewal eviction information"
 msgstr "NY Homes and Community Renewal eviction information"
 
-#: src/hooks/useCriteriaResults.tsx:618
+#: src/hooks/useCriteriaResults.tsx:626
 msgid "NYCHA and PACT/RAD apartments are not covered by Good Cause because they already have stronger tenant protections than Good Cause provides."
 msgstr "NYCHA and PACT/RAD apartments are not covered by Good Cause because they already have stronger tenant protections than Good Cause provides."
 
-#: src/hooks/useCriteriaResults.tsx:531
-#: src/hooks/useCriteriaResults.tsx:557
+#: src/hooks/useCriteriaResults.tsx:539
+#: src/hooks/useCriteriaResults.tsx:565
 msgid "NYCHA and PACT/RAD apartments are not covered by Good Cause because they already have stronger tenant protections than Good Cause."
 msgstr "NYCHA and PACT/RAD apartments are not covered by Good Cause because they already have stronger tenant protections than Good Cause."
 
@@ -999,7 +999,7 @@ msgstr "NYLAG's Public Housing Justice Project"
 msgid "Once you find the name of your building’s owner, remember it because you’ll need it in Step 2."
 msgstr "Once you find the name of your building’s owner, remember it because you’ll need it in Step 2."
 
-#: src/hooks/useCriteriaResults.tsx:167
+#: src/hooks/useCriteriaResults.tsx:170
 msgid "other buildings."
 msgstr "other buildings."
 
@@ -1019,16 +1019,16 @@ msgstr "PACT Fact Sheet"
 msgid "PACT Rights and Responsibilities Fact Sheet"
 msgstr "PACT Rights and Responsibilities Fact Sheet"
 
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:244
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:243
 msgid "Phone number"
 msgstr "Phone number"
 
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:165
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:164
 msgid "Phone number (optional)"
 msgstr "Phone number (optional)"
 
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:185
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:257
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:184
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:256
 msgid "Phone number submitted"
 msgstr "Phone number submitted"
 
@@ -1101,25 +1101,25 @@ msgstr "Protections that all NYC tenants have"
 msgid "Protections under Good Cause"
 msgstr "Protections under Good Cause"
 
-#: src/hooks/useCriteriaResults.tsx:434
+#: src/hooks/useCriteriaResults.tsx:442
 msgid "Public data sources indicate that your building is {bldgTypeName}, and so is not covered by Good Cause Eviction."
 msgstr "Public data sources indicate that your building is {bldgTypeName}, and so is not covered by Good Cause Eviction."
 
-#: src/hooks/useCriteriaResults.tsx:429
+#: src/hooks/useCriteriaResults.tsx:437
 msgid "Public data sources indicate that your building is not a condo, co-op, or other exempt category."
 msgstr "Public data sources indicate that your building is not a condo, co-op, or other exempt category."
 
-#: src/Components/Pages/Form/Survey.tsx:631
+#: src/Components/Pages/Form/Survey.tsx:634
 msgid "Publicly available data sources do not indicate that your building is part of a subsidized housing program."
 msgstr "Publicly available data sources do not indicate that your building is part of a subsidized housing program."
 
 #. placeholder {0}: formatNumber(rsUnits)
 #. placeholder {1}: formatNumber(bldgUnits)
-#: src/Components/Pages/Form/Survey.tsx:518
+#: src/Components/Pages/Form/Survey.tsx:521
 msgid "Publicly available data sources indicate that {0} of the {1} apartments in your building are registered as rent stabilized."
 msgstr "Publicly available data sources indicate that {0} of the {1} apartments in your building are registered as rent stabilized."
 
-#: src/Components/Pages/Form/Survey.tsx:508
+#: src/Components/Pages/Form/Survey.tsx:511
 msgid "Publicly available data sources indicate that all apartments in your building are registered as rent stabilized."
 msgstr "Publicly available data sources indicate that all apartments in your building are registered as rent stabilized."
 
@@ -1132,21 +1132,21 @@ msgstr "Publicly available data sources indicate that there {0} in your building
 #~ msgid "Publicly available data sources indicate that your building {0}, which is considered subsidized housing."
 #~ msgstr "Publicly available data sources indicate that your building {0}, which is considered subsidized housing."
 
-#: src/Components/Pages/Form/Survey.tsx:618
+#: src/Components/Pages/Form/Survey.tsx:621
 msgid "Publicly available data sources indicate that your building <0/>, which is considered subsidized housing."
 msgstr "Publicly available data sources indicate that your building <0/>, which is considered subsidized housing."
 
-#: src/Components/Pages/Form/Survey.tsx:606
+#: src/Components/Pages/Form/Survey.tsx:609
 msgid "Publicly available data sources indicate that your building is part of NYCHA."
 msgstr "Publicly available data sources indicate that your building is part of NYCHA."
 
 #. placeholder {0}: active421a ? "421a" : "J51"
-#: src/Components/Pages/Form/Survey.tsx:495
+#: src/Components/Pages/Form/Survey.tsx:498
 msgid "Publicly available data sources indicate that your building receives the {0} tax incentive. This means your apartment is rent stabilized."
 msgstr "Publicly available data sources indicate that your building receives the {0} tax incentive. This means your apartment is rent stabilized."
 
 #. placeholder {0}: formatNumber(relatedProperties)
-#: src/hooks/useCriteriaResults.tsx:160
+#: src/hooks/useCriteriaResults.tsx:163
 msgid "publicly available data sources indicate that your landlord may be associated with {0}"
 msgstr "publicly available data sources indicate that your landlord may be associated with {0}"
 
@@ -1154,11 +1154,11 @@ msgstr "publicly available data sources indicate that your landlord may be assoc
 msgid "Reach out to external resources"
 msgstr "Reach out to external resources"
 
-#: src/Components/Pages/Form/Survey.tsx:649
+#: src/Components/Pages/Form/Survey.tsx:652
 msgid "receives a HUD Project-Based subsidy"
 msgstr "receives a HUD Project-Based subsidy"
 
-#: src/Components/Pages/Form/Survey.tsx:651
+#: src/Components/Pages/Form/Survey.tsx:654
 msgid "receives the Low-Income Housing Tax Credit (LIHTC)"
 msgstr "receives the Low-Income Housing Tax Credit (LIHTC)"
 
@@ -1180,7 +1180,7 @@ msgstr "Rent increase calculator"
 msgid "Rent stabilization"
 msgstr "Rent stabilization"
 
-#: src/hooks/useCriteriaResults.tsx:331
+#: src/hooks/useCriteriaResults.tsx:339
 msgid "Rent stabilized apartments are not covered by Good Cause Eviction because they already have stronger tenant protections than Good Cause."
 msgstr "Rent stabilized apartments are not covered by Good Cause Eviction because they already have stronger tenant protections than Good Cause."
 
@@ -1224,7 +1224,7 @@ msgstr "Search new address"
 msgid "See if you are eligible for a free attorney in housing court"
 msgstr "See if you are eligible for a free attorney in housing court"
 
-#: src/Components/Pages/Form/Survey.tsx:364
+#: src/Components/Pages/Form/Survey.tsx:367
 msgid "See your results"
 msgstr "See your results"
 
@@ -1248,8 +1248,8 @@ msgstr "Showing {visibleCount} of {totalCount} buildings that your landlord may 
 msgid "Since your apartment is covered by Good Cause Eviction, there is a good chance other apartments in your building are covered as well. Organizing with your neighbors can help you assert your rights as a group."
 msgstr "Since your apartment is covered by Good Cause Eviction, there is a good chance other apartments in your building are covered as well. Organizing with your neighbors can help you assert your rights as a group."
 
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:191
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:263
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:190
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:262
 msgid "Something went wrong. Try again later."
 msgstr "Something went wrong. Try again later."
 
@@ -1261,7 +1261,7 @@ msgstr "Source of income discrimination is the illegal practice by landlords, ow
 msgid "Stronger protections"
 msgstr "Stronger protections"
 
-#: src/hooks/useCriteriaResults.tsx:256
+#: src/hooks/useCriteriaResults.tsx:261
 msgid "studio"
 msgstr "studio"
 
@@ -1269,14 +1269,14 @@ msgstr "studio"
 msgid "Studio"
 msgstr "Studio"
 
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:176
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:203
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:283
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:175
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:202
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:282
 msgid "Submit"
 msgstr "Submit"
 
-#: src/hooks/useCriteriaResults.tsx:540
-#: src/hooks/useCriteriaResults.tsx:638
+#: src/hooks/useCriteriaResults.tsx:548
+#: src/hooks/useCriteriaResults.tsx:646
 msgid "Subsidized buildings are not covered by Good Cause Eviction because they already have similar, and sometimes stronger, existing tenant protections."
 msgstr "Subsidized buildings are not covered by Good Cause Eviction because they already have similar, and sometimes stronger, existing tenant protections."
 
@@ -1330,7 +1330,7 @@ msgstr "Terms of use"
 msgid "Terms of Use"
 msgstr "Terms of Use"
 
-#: src/hooks/useCriteriaResults.tsx:302
+#: src/hooks/useCriteriaResults.tsx:308
 msgid "The apartment must not be rent stabilized."
 msgstr "The apartment must not be rent stabilized."
 
@@ -1338,18 +1338,18 @@ msgstr "The apartment must not be rent stabilized."
 msgid "The best way to confirm the owner of your building is to review your building’s official real estate transaction documents and look for the owner’s signature. We have provided links to these documents, below."
 msgstr "The best way to confirm the owner of your building is to review your building’s official real estate transaction documents and look for the owner’s signature. We have provided links to these documents, below."
 
-#: src/hooks/useCriteriaResults.tsx:467
+#: src/hooks/useCriteriaResults.tsx:475
 msgid "The building must have received its certificate of occupancy before 2009."
 msgstr "The building must have received its certificate of occupancy before 2009."
 
-#: src/hooks/useCriteriaResults.tsx:390
+#: src/hooks/useCriteriaResults.tsx:398
 msgid "The building must not be a condo, co-op, or other exempt building types."
 msgstr "The building must not be a condo, co-op, or other exempt building types."
 
-#: src/hooks/useCriteriaResults.tsx:518
-#: src/hooks/useCriteriaResults.tsx:570
-#: src/hooks/useCriteriaResults.tsx:593
-#: src/hooks/useCriteriaResults.tsx:648
+#: src/hooks/useCriteriaResults.tsx:526
+#: src/hooks/useCriteriaResults.tsx:578
+#: src/hooks/useCriteriaResults.tsx:601
+#: src/hooks/useCriteriaResults.tsx:656
 msgid "The building must not be part of NYCHA, PACT/RAD, or other subsidized housing."
 msgstr "The building must not be part of NYCHA, PACT/RAD, or other subsidized housing."
 
@@ -1363,7 +1363,7 @@ msgstr "The Good Cause law establishes a Reasonable Rent Increase, which is set 
 msgid "The information on this website does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing."
 msgstr "The information on this website does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing."
 
-#: src/hooks/useCriteriaResults.tsx:90
+#: src/hooks/useCriteriaResults.tsx:93
 msgid "The landlord of the building must own more than 10 apartments."
 msgstr "The landlord of the building must own more than 10 apartments."
 
@@ -1426,7 +1426,7 @@ msgstr "To be covered by the law, your apartment must meet several requirements.
 msgid "To find other buildings your landlord might own, you can:"
 msgstr "To find other buildings your landlord might own, you can:"
 
-#: src/Components/Pages/Form/Survey.tsx:374
+#: src/Components/Pages/Form/Survey.tsx:377
 msgid "To help guide your answer"
 msgstr "To help guide your answer"
 
@@ -1490,16 +1490,16 @@ msgstr "View all documents from Richmond County Clerk"
 msgid "View all documents in ACRIS"
 msgstr "View all documents in ACRIS"
 
-#: src/Components/Pages/Form/Survey.tsx:473
-#: src/Components/Pages/Form/Survey.tsx:501
-#: src/Components/Pages/Form/Survey.tsx:591
-#: src/hooks/useCriteriaResults.tsx:99
-#: src/hooks/useCriteriaResults.tsx:230
-#: src/hooks/useCriteriaResults.tsx:311
-#: src/hooks/useCriteriaResults.tsx:316
-#: src/hooks/useCriteriaResults.tsx:440
-#: src/hooks/useCriteriaResults.tsx:489
-#: src/hooks/useCriteriaResults.tsx:511
+#: src/Components/Pages/Form/Survey.tsx:476
+#: src/Components/Pages/Form/Survey.tsx:504
+#: src/Components/Pages/Form/Survey.tsx:594
+#: src/hooks/useCriteriaResults.tsx:102
+#: src/hooks/useCriteriaResults.tsx:235
+#: src/hooks/useCriteriaResults.tsx:317
+#: src/hooks/useCriteriaResults.tsx:322
+#: src/hooks/useCriteriaResults.tsx:448
+#: src/hooks/useCriteriaResults.tsx:497
+#: src/hooks/useCriteriaResults.tsx:519
 msgid "View source"
 msgstr "View source"
 
@@ -1523,7 +1523,7 @@ msgstr "Visit JustFix"
 msgid "We are unable to directly link to specific documents for properties in Staten Island. Please view all documents for this property, and refer to the video above to learn how to identify the documents most likely to contain the owner's name and signature."
 msgstr "We are unable to directly link to specific documents for properties in Staten Island. Please view all documents for this property, and refer to the video above to learn how to identify the documents most likely to contain the owner's name and signature."
 
-#: src/Components/Pages/Form/Survey.tsx:390
+#: src/Components/Pages/Form/Survey.tsx:393
 msgid "We check for NYCHA, Mitchell-Lama, HDFC, LIHTC, Project Section 8, and various HPD and HUD programs. If you know the public data is incorrect, use these tips to guide your answer:"
 msgstr "We check for NYCHA, Mitchell-Lama, HDFC, LIHTC, Project Section 8, and various HPD and HUD programs. If you know the public data is incorrect, use these tips to guide your answer:"
 
@@ -1531,7 +1531,7 @@ msgstr "We check for NYCHA, Mitchell-Lama, HDFC, LIHTC, Project Section 8, and v
 msgid "We need to confirm if your apartment is rent stabilized"
 msgstr "We need to confirm if your apartment is rent stabilized"
 
-#: src/Components/Pages/Results/Results.tsx:475
+#: src/Components/Pages/Results/Results.tsx:477
 msgid "We need to confirm if your landlord owns more than 10 apartments"
 msgstr "We need to confirm if your landlord owns more than 10 apartments"
 
@@ -1539,8 +1539,8 @@ msgstr "We need to confirm if your landlord owns more than 10 apartments"
 msgid "We were unable to find relevant documents containing owner names and/or signatures for this building."
 msgstr "We were unable to find relevant documents containing owner names and/or signatures for this building."
 
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:194
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:268
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:193
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:267
 msgid "We will never call you or share your phone number. We may text you later in the year to see how things are going. Opt-out at any time."
 msgstr "We will never call you or share your phone number. We may text you later in the year to see how things are going. Opt-out at any time."
 
@@ -1594,7 +1594,7 @@ msgstr "Yes, NYCHA / PACT-RAD"
 msgid "You are not covered by Good Cause because you have existing eviction protections through your building’s subsidy program"
 msgstr "You are not covered by Good Cause because you have existing eviction protections through your building’s subsidy program"
 
-#: src/hooks/useCriteriaResults.tsx:348
+#: src/hooks/useCriteriaResults.tsx:356
 msgid "you are not sure if your apartment is"
 msgstr "you are not sure if your apartment is"
 
@@ -1626,23 +1626,23 @@ msgstr "You only need to find the name or signature of your building’s owner o
 #. placeholder {0}: rentStabilized === "NO" ? ( <Trans>your apartment is not</Trans> ) : ( <Trans>you are not sure if your apartment is</Trans> )
 #. placeholder {2}: allUnitsRS ? ( <Trans> all apartments in your building are registered as rent stabilized. </Trans> ) : ( <Trans> your building receives the {activeJ51 ? "421a" : "J51"} tax incentive, which means your apartment should be rent stabilized. </Trans> )
 #. placeholder {3}: allUnitsRS ? wowLink : subsidyLink
-#: src/hooks/useCriteriaResults.tsx:343
+#: src/hooks/useCriteriaResults.tsx:351
 msgid "You reported that {0} rent stabilized, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that{2} {3}If those sources are correct, then you may already have stronger tenant protections than Good Cause Eviction provides. {guideLink}"
 msgstr "You reported that {0} rent stabilized, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that{2} {3}If those sources are correct, then you may already have stronger tenant protections than Good Cause Eviction provides. {guideLink}"
 
-#: src/hooks/useCriteriaResults.tsx:369
+#: src/hooks/useCriteriaResults.tsx:377
 msgid "You reported that you are not sure if your apartment is rent stabilized. {guideLink}"
 msgstr "You reported that you are not sure if your apartment is rent stabilized. {guideLink}"
 
-#: src/hooks/useCriteriaResults.tsx:367
+#: src/hooks/useCriteriaResults.tsx:375
 msgid "You reported that your apartment is not rent stabilized."
 msgstr "You reported that your apartment is not rent stabilized."
 
-#: src/hooks/useCriteriaResults.tsx:337
+#: src/hooks/useCriteriaResults.tsx:345
 msgid "You reported that your apartment is rent stabilized."
 msgstr "You reported that your apartment is rent stabilized."
 
-#: src/hooks/useCriteriaResults.tsx:601
+#: src/hooks/useCriteriaResults.tsx:609
 msgid "You reported that your building is not part of any subsidized housing programs, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building is part of NYCHA or PACT/RAD."
 msgstr "You reported that your building is not part of any subsidized housing programs, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building is part of NYCHA or PACT/RAD."
 
@@ -1650,7 +1650,7 @@ msgstr "You reported that your building is not part of any subsidized housing pr
 #~ msgid "You reported that your building is not part of any subsidized housing programs, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building is part of NYCHA or PACT/RAD. {sourceLink} If those sources are correct, you may have existing tenant protections through NYCHA or PACT/RAD."
 #~ msgstr "You reported that your building is not part of any subsidized housing programs, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building is part of NYCHA or PACT/RAD. {sourceLink} If those sources are correct, you may have existing tenant protections through NYCHA or PACT/RAD."
 
-#: src/hooks/useCriteriaResults.tsx:548
+#: src/hooks/useCriteriaResults.tsx:556
 msgid "You reported that your building is not part of NYCHA, PACT/RAD, or other subsidized housing programs."
 msgstr "You reported that your building is not part of NYCHA, PACT/RAD, or other subsidized housing programs."
 
@@ -1658,7 +1658,7 @@ msgstr "You reported that your building is not part of NYCHA, PACT/RAD, or other
 #~ msgid "You reported that your building is not part of NYCHA, PACT/RAD, or other subsidized housing, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building {0} , which is considered subsidized housing. {sourceLink} If those sources are correct, you may have existing tenant protections through your building’s subsidy program."
 #~ msgstr "You reported that your building is not part of NYCHA, PACT/RAD, or other subsidized housing, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building {0} , which is considered subsidized housing. {sourceLink} If those sources are correct, you may have existing tenant protections through your building’s subsidy program."
 
-#: src/hooks/useCriteriaResults.tsx:656
+#: src/hooks/useCriteriaResults.tsx:664
 msgid "You reported that your building is not part of NYCHA, PACT/RAD, or other subsidized housing, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building <0/> , which is considered subsidized housing."
 msgstr "You reported that your building is not part of NYCHA, PACT/RAD, or other subsidized housing, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building <0/> , which is considered subsidized housing."
 
@@ -1670,16 +1670,16 @@ msgstr "You reported that your building is not part of NYCHA, PACT/RAD, or other
 #~ msgid "You reported that your building is part of NYCHA or PACT/RAD, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building {0}, which is considered subsidized housing. {sourceLink} If those sources are correct, then your protections may be different than the protections of NYCHA or PACT/RAD."
 #~ msgstr "You reported that your building is part of NYCHA or PACT/RAD, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building {0}, which is considered subsidized housing. {sourceLink} If those sources are correct, then your protections may be different than the protections of NYCHA or PACT/RAD."
 
-#: src/hooks/useCriteriaResults.tsx:626
+#: src/hooks/useCriteriaResults.tsx:634
 msgid "You reported that your building is part of NYCHA or PACT/RAD, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building <0/>, which is considered subsidized housing. {sourceLink} If those sources are correct, then your protections may be different than the protections of NYCHA or PACT/RAD."
 msgstr "You reported that your building is part of NYCHA or PACT/RAD, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building <0/>, which is considered subsidized housing. {sourceLink} If those sources are correct, then your protections may be different than the protections of NYCHA or PACT/RAD."
 
-#: src/hooks/useCriteriaResults.tsx:525
-#: src/hooks/useCriteriaResults.tsx:564
+#: src/hooks/useCriteriaResults.tsx:533
+#: src/hooks/useCriteriaResults.tsx:572
 msgid "You reported that your building is part of NYCHA or PACT/RAD."
 msgstr "You reported that your building is part of NYCHA or PACT/RAD."
 
-#: src/hooks/useCriteriaResults.tsx:578
+#: src/hooks/useCriteriaResults.tsx:586
 msgid "You reported that your building is subsidized, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building is part of NYCHA or PACT/RAD."
 msgstr "You reported that your building is subsidized, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building is part of NYCHA or PACT/RAD."
 
@@ -1687,13 +1687,13 @@ msgstr "You reported that your building is subsidized, and we are using your ans
 #~ msgid "You reported that your building is subsidized, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building is part of NYCHA or PACT/RAD. {sourceLink} If those sources are correct, then you may already have stronger tenant protections than other subsidized housing programs."
 #~ msgstr "You reported that your building is subsidized, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building is part of NYCHA or PACT/RAD. {sourceLink} If those sources are correct, then you may already have stronger tenant protections than other subsidized housing programs."
 
-#: src/hooks/useCriteriaResults.tsx:537
-#: src/hooks/useCriteriaResults.tsx:645
+#: src/hooks/useCriteriaResults.tsx:545
+#: src/hooks/useCriteriaResults.tsx:653
 msgid "You reported that your building is subsidized."
 msgstr "You reported that your building is subsidized."
 
 #. placeholder {0}: formatMoney(rent, 0)
-#: src/hooks/useCriteriaResults.tsx:278
+#: src/hooks/useCriteriaResults.tsx:283
 msgid "You reported that your rent is {0}."
 msgstr "You reported that your rent is {0}."
 
@@ -1709,49 +1709,49 @@ msgstr "You told us that you are unsure if you are rent stabilized. If your apar
 msgid "You’re not alone. Too many landlords care more about getting rich off our rent money than providing us with decent homes."
 msgstr "You’re not alone. Too many landlords care more about getting rich off our rent money than providing us with decent homes."
 
-#: src/hooks/useCriteriaResults.tsx:346
+#: src/hooks/useCriteriaResults.tsx:354
 msgid "your apartment is not"
 msgstr "your apartment is not"
 
 #. placeholder {0}: formatNumber(unitsres)
-#: src/hooks/useCriteriaResults.tsx:149
+#: src/hooks/useCriteriaResults.tsx:152
 msgid "Your building has {0} apartments and you reported that your landlord does not own other buildings."
 msgstr "Your building has {0} apartments and you reported that your landlord does not own other buildings."
 
 #. placeholder {0}: formatNumber(unitsres)
-#: src/hooks/useCriteriaResults.tsx:211
+#: src/hooks/useCriteriaResults.tsx:216
 msgid "Your building has {0} apartments and you reported that your landlord lives in the building."
 msgstr "Your building has {0} apartments and you reported that your landlord lives in the building."
 
 #. placeholder {0}: formatNumber(unitsres)
-#: src/hooks/useCriteriaResults.tsx:144
-#: src/hooks/useCriteriaResults.tsx:206
+#: src/hooks/useCriteriaResults.tsx:147
+#: src/hooks/useCriteriaResults.tsx:211
 msgid "Your building has {0} apartments."
 msgstr "Your building has {0} apartments."
 
 #. placeholder {0}: formatNumber(unitsres)
-#: src/hooks/useCriteriaResults.tsx:136
+#: src/hooks/useCriteriaResults.tsx:139
 msgid "Your building has {0} apartments. Additionally, your landlord may own other buildings in the city. {wowLink}"
 msgstr "Your building has {0} apartments. Additionally, your landlord may own other buildings in the city. {wowLink}"
 
-#: src/hooks/useCriteriaResults.tsx:117
+#: src/hooks/useCriteriaResults.tsx:120
 msgid "Your building has {pluralApartments} and you reported that your landlord owns more than 10 apartments across multiple buildings. Additionally, your landlord may own other buildings in the city. {wowLink}"
 msgstr "Your building has {pluralApartments} and you reported that your landlord owns more than 10 apartments across multiple buildings. Additionally, your landlord may own other buildings in the city. {wowLink}"
 
-#: src/hooks/useCriteriaResults.tsx:126
+#: src/hooks/useCriteriaResults.tsx:129
 msgid "Your building has {unitsres, plural, one {# apartment} other {# apartments}}, and you reported that your landlord owns more than 10 apartments across multiple buildings."
 msgstr "Your building has {unitsres, plural, one {# apartment} other {# apartments}}, and you reported that your landlord owns more than 10 apartments across multiple buildings."
 
 #. placeholder {0}: formatNumber(unitsres)
-#: src/hooks/useCriteriaResults.tsx:219
+#: src/hooks/useCriteriaResults.tsx:224
 msgid "Your building has ${0} apartments and you reported that your landlord does not live in the building."
 msgstr "Your building has ${0} apartments and you reported that your landlord does not live in the building."
 
-#: src/hooks/useCriteriaResults.tsx:476
+#: src/hooks/useCriteriaResults.tsx:484
 msgid "Your building has no new recorded certificate of occupancy since 2009."
 msgstr "Your building has no new recorded certificate of occupancy since 2009."
 
-#: src/hooks/useCriteriaResults.tsx:158
+#: src/hooks/useCriteriaResults.tsx:161
 msgid "Your building has only {pluralApartments}, but"
 msgstr "Your building has only {pluralApartments}, but"
 
@@ -1760,11 +1760,11 @@ msgstr "Your building has only {pluralApartments}, but"
 #~ msgstr "Your building has only {pluralApartments}, but{1} other buildings. <0>Find your landlord’s other buildings</0>"
 
 #. placeholder {0}: activeJ51 ? "421a" : "J51"
-#: src/hooks/useCriteriaResults.tsx:357
+#: src/hooks/useCriteriaResults.tsx:365
 msgid "your building receives the {0} tax incentive, which means your apartment should be rent stabilized."
 msgstr "your building receives the {0} tax incentive, which means your apartment should be rent stabilized."
 
-#: src/hooks/useCriteriaResults.tsx:480
+#: src/hooks/useCriteriaResults.tsx:488
 msgid "Your building was issued a certificate of occupancy on {latestCoDateFormatted}."
 msgstr "Your building was issued a certificate of occupancy on {latestCoDateFormatted}."
 
@@ -1788,7 +1788,7 @@ msgstr "Your eviction protections"
 msgid "Your landlord can’t evict you based on your race, religion, gender, national origin, familial status, or disability. New York State law promises protection from discrimination, banning bias based on age, sexual orientation, and military status."
 msgstr "Your landlord can’t evict you based on your race, religion, gender, national origin, familial status, or disability. New York State law promises protection from discrimination, banning bias based on age, sexual orientation, and military status."
 
-#: src/hooks/useCriteriaResults.tsx:165
+#: src/hooks/useCriteriaResults.tsx:168
 msgid "your landlord may own"
 msgstr "your landlord may own"
 

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -54,7 +54,7 @@ msgstr "{docType}"
 msgid "{unitsres, plural, one {# apartment} other {# apartments}}"
 msgstr "{unitsres, plural, one {# apartment} other {# apartments}}"
 
-#: src/Components/TopBar/TopBar.tsx:29
+#: src/Components/TopBar/TopBar.tsx:31
 msgid "<0>By</0> <1>Housing Justice for All</1> <2>&</2> <3>JustFix</3>"
 msgstr "<0>By</0> <1>Housing Justice for All</1> <2>&</2> <3>JustFix</3>"
 
@@ -78,27 +78,27 @@ msgstr "<0>Tip:</0> If, in any one of the documents below, you find an owner’s
 msgid "<0>Tip:</0> We recommend doing the following research on a desktop computer. If you have not already, please watch the video, above, for step-by-step instructions on how to complete Steps 1 and 2."
 msgstr "<0>Tip:</0> We recommend doing the following research on a desktop computer. If you have not already, please watch the video, above, for step-by-step instructions on how to complete Steps 1 and 2."
 
-#: src/Components/Pages/Results/Results.tsx:563
+#: src/Components/Pages/Results/Results.tsx:570
 msgid "<0>You are</0> <1>likely covered</1> by Good Cause Eviction"
 msgstr "<0>You are</0> <1>likely covered</1> by Good Cause Eviction"
 
-#: src/Components/Pages/Results/Results.tsx:544
+#: src/Components/Pages/Results/Results.tsx:551
 msgid "<0>You are</0> <1>likely not covered</1> <2/>by Good Cause Eviction"
 msgstr "<0>You are</0> <1>likely not covered</1> <2/>by Good Cause Eviction"
 
-#: src/Components/Pages/Results/Results.tsx:535
+#: src/Components/Pages/Results/Results.tsx:542
 msgid "<0>You</0> <1>might be covered</1> by Good Cause Eviction"
 msgstr "<0>You</0> <1>might be covered</1> by Good Cause Eviction"
 
-#: src/Components/Pages/Results/Results.tsx:572
+#: src/Components/Pages/Results/Results.tsx:579
 msgid "<0>Your apartment is part of</0> <1>NYCHA or PACT/RAD</1> which provides stronger protections than Good Cause Eviction"
 msgstr "<0>Your apartment is part of</0> <1>NYCHA or PACT/RAD</1> which provides stronger protections than Good Cause Eviction"
 
-#: src/Components/Pages/Results/Results.tsx:554
+#: src/Components/Pages/Results/Results.tsx:561
 msgid "<0>Your apartment is</0> <1>rent stabilized</1> which provides stronger protections than Good Cause Eviction"
 msgstr "<0>Your apartment is</0> <1>rent stabilized</1> which provides stronger protections than Good Cause Eviction"
 
-#: src/Components/Pages/Results/Results.tsx:583
+#: src/Components/Pages/Results/Results.tsx:590
 msgid "<0>Your building is</0> <1>subsidized</1> which provides existing eviction protections"
 msgstr "<0>Your building is</0> <1>subsidized</1> which provides existing eviction protections"
 
@@ -176,7 +176,7 @@ msgstr "Address"
 
 #: src/Components/Pages/PortfolioSize/PortfolioSize.tsx:277
 #: src/Components/Pages/RentStabilization/RentStabilization.tsx:144
-#: src/Components/Pages/Results/Results.tsx:490
+#: src/Components/Pages/Results/Results.tsx:497
 msgid "Adjust survey answers"
 msgstr "Adjust survey answers"
 
@@ -209,7 +209,7 @@ msgstr "Assignment of leases & rents"
 msgid "Attend a walk-in Clinic hosted by the Met Council on Housing"
 msgstr "Attend a walk-in Clinic hosted by the Met Council on Housing"
 
-#: src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx:113
+#: src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx:114
 #: src/Components/Pages/Form/Survey.tsx:359
 msgid "Back"
 msgstr "Back"
@@ -217,6 +217,10 @@ msgstr "Back"
 #: src/Components/Header/Header.tsx:37
 msgid "Back to Result"
 msgstr "Back to Result"
+
+#: src/Components/Pages/Results/Results.tsx:406
+msgid "Back to survey"
+msgstr "Back to survey"
 
 #: src/Components/Pages/PortfolioSize/PortfolioSize.tsx:203
 msgid "Based on data from the website {wowLink}, we gather a list of properties that the owner of your building may be associated with. For each property, we include links to important real estate transaction documents."
@@ -238,9 +242,13 @@ msgstr "Because your building has fewer than 6 units it is very unlikely that yo
 msgid "Because your building was built after 1974 and is not part of 421a or J51 tax incentive programs, it is very unlikely that your apartment is rent stabilized. Additionally, based on publicly available, no rent stabilized apartments were registered in your building in recent years."
 msgstr "Because your building was built after 1974 and is not part of 421a or J51 tax incentive programs, it is very unlikely that your apartment is rent stabilized. Additionally, based on publicly available, no rent stabilized apartments were registered in your building in recent years."
 
-#: src/Components/Footer/Footer.tsx:64
+#: src/Components/Footer/Footer.tsx:67
 msgid "By <0>Housing Justice for All</0> & <1>JustFix</1>"
 msgstr "By <0>Housing Justice for All</0> & <1>JustFix</1>"
+
+#: src/Components/Pages/RentCalculator/RentCalculator.tsx:86
+msgid "Calculate"
+msgstr "Calculate"
 
 #: src/Components/Pages/Home/Home.tsx:118
 msgid "Calculate your max rent increase."
@@ -267,7 +275,7 @@ msgstr "Check your lease renewal"
 msgid "Check your most recent lease renewal"
 msgstr "Check your most recent lease renewal"
 
-#: src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx:79
+#: src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx:80
 msgid "City data indicates that there aren’t any residential units at this address."
 msgstr "City data indicates that there aren’t any residential units at this address."
 
@@ -295,15 +303,15 @@ msgstr "Close"
 msgid "Close modal"
 msgstr "Close modal"
 
-#: src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx:117
+#: src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx:118
 msgid "Confirm"
 msgstr "Confirm"
 
-#: src/Components/Pages/Results/Results.tsx:624
+#: src/Components/Pages/Results/Results.tsx:631
 msgid "Copied"
 msgstr "Copied"
 
-#: src/Components/Pages/Results/Results.tsx:616
+#: src/Components/Pages/Results/Results.tsx:623
 msgid "Copy goodcausenyc.org"
 msgstr "Copy goodcausenyc.org"
 
@@ -315,7 +323,7 @@ msgstr "Demand notice"
 msgid "Demolition"
 msgstr "Demolition"
 
-#: src/Components/Footer/Footer.tsx:20
+#: src/Components/Footer/Footer.tsx:23
 msgid "Disclaimer"
 msgstr "Disclaimer"
 
@@ -378,7 +386,7 @@ msgstr "FAQs to help guide your answer"
 msgid "February 19, 2025"
 msgstr "February 19, 2025"
 
-#: src/Components/Footer/Footer.tsx:52
+#: src/Components/Footer/Footer.tsx:55
 msgid "Feedback Form"
 msgstr "Feedback Form"
 
@@ -386,7 +394,7 @@ msgstr "Feedback Form"
 msgid "Fill out the request form"
 msgstr "Fill out the request form"
 
-#: src/Components/Pages/Results/Results.tsx:483
+#: src/Components/Pages/Results/Results.tsx:490
 msgid "Find other buildings your landlord owns"
 msgstr "Find other buildings your landlord owns"
 
@@ -401,7 +409,7 @@ msgid "Find out if you’re covered by Good Cause"
 msgstr "Find out if you’re covered by Good Cause"
 
 #: src/Components/Pages/RentStabilization/RentStabilization.tsx:42
-#: src/Components/Pages/Results/Results.tsx:460
+#: src/Components/Pages/Results/Results.tsx:467
 #: src/Components/Pages/TenantRights/TenantRights.tsx:44
 #: src/hooks/useCriteriaResults.tsx:321
 msgid "Find out if your apartment is rent stabilized"
@@ -410,6 +418,10 @@ msgstr "Find out if your apartment is rent stabilized"
 #: src/Components/Pages/PortfolioSize/PortfolioSize.tsx:70
 msgid "Find out if your landlord owns other buildings"
 msgstr "Find out if your landlord owns other buildings"
+
+#: src/hooks/useCriteriaResults.tsx:169
+msgid "Find your landlord’s other buildings"
+msgstr "Find your landlord’s other buildings"
 
 #. placeholder {0}: bedrooms === "STUDIO" ? ( <Trans>studio</Trans> ) : ( <Trans>{bedrooms} bedroom</Trans> )
 #. placeholder {1}: formatMoney(RENT_CUTOFFS[bedrooms], 0)
@@ -438,7 +450,7 @@ msgid "Get started"
 msgstr "Get started"
 
 #. placeholder {0}: bldgData.unitsres
-#: src/Components/Pages/Results/Results.tsx:475
+#: src/Components/Pages/Results/Results.tsx:482
 msgid "Good Cause Eviction law only covers tenants whose landlord owns more than 10 apartments. Your building has only {0} apartments, but your landlord may own other buildings."
 msgstr "Good Cause Eviction law only covers tenants whose landlord owns more than 10 apartments. Your building has only {0} apartments, but your landlord may own other buildings."
 
@@ -458,8 +470,8 @@ msgstr "Good Cause Eviction protections went into effect on April 20th, 2024. If
 msgid "Good Cause law can be complex to understand and to use to protect yourself. This site exists to make it easier for you and your neighbors to understand your tenant protections and to assert your rights."
 msgstr "Good Cause law can be complex to understand and to use to protect yourself. This site exists to make it easier for you and your neighbors to understand your tenant protections and to assert your rights."
 
-#: src/Components/Footer/Footer.tsx:60
-#: src/Components/TopBar/TopBar.tsx:24
+#: src/Components/Footer/Footer.tsx:63
+#: src/Components/TopBar/TopBar.tsx:26
 msgid "Good Cause NYC"
 msgstr "Good Cause NYC"
 
@@ -472,7 +484,7 @@ msgid "Has your landlord raised your rent? Is your landlord refusing to do basic
 msgstr "Has your landlord raised your rent? Is your landlord refusing to do basic repairs? Are you worried about getting evicted or non-renewed?"
 
 #: src/Components/Pages/PortfolioSize/PortfolioSize.tsx:276
-#: src/Components/Pages/Results/Results.tsx:489
+#: src/Components/Pages/Results/Results.tsx:496
 msgid "Have you learned something new?"
 msgstr "Have you learned something new?"
 
@@ -517,7 +529,7 @@ msgstr "How to find other apartments your landlord owns"
 msgid "How to find out if your apartment is rent stabilized"
 msgstr "How to find out if your apartment is rent stabilized"
 
-#: src/Components/Pages/Results/Results.tsx:376
+#: src/Components/Pages/Results/Results.tsx:378
 msgid "How we determined your coverage"
 msgstr "How we determined your coverage"
 
@@ -716,7 +728,7 @@ msgstr "Landlord portfolio size"
 msgid "Landlords can increase the rent more than the reasonable rent increase but they must explain why and must point to increases in their costs or substantial repairs they did to the apartment or building."
 msgstr "Landlords can increase the rent more than the reasonable rent increase but they must explain why and must point to increases in their costs or substantial repairs they did to the apartment or building."
 
-#: src/Components/Footer/Footer.tsx:13
+#: src/Components/Footer/Footer.tsx:16
 msgid "Language"
 msgstr "Language"
 
@@ -858,7 +870,7 @@ msgstr "Loading your results..."
 msgid "manufactured housing"
 msgstr "manufactured housing"
 
-#: src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx:95
+#: src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx:96
 msgid "Map showing location of the entered address."
 msgstr "Map showing location of the entered address."
 
@@ -906,6 +918,10 @@ msgstr "More resources about your rights as an NYC tenant"
 #: src/helpers.ts:165
 msgid "Mortgage"
 msgstr "Mortgage"
+
+#: src/Components/Pages/Results/Results.tsx:405
+msgid "Need to update your information?"
+msgstr "Need to update your information?"
 
 #: src/Components/Pages/Form/Survey.tsx:232
 #: src/Components/Pages/Form/Survey.tsx:307
@@ -983,6 +999,10 @@ msgstr "NYLAG's Public Housing Justice Project"
 msgid "Once you find the name of your building’s owner, remember it because you’ll need it in Step 2."
 msgstr "Once you find the name of your building’s owner, remember it because you’ll need it in Step 2."
 
+#: src/hooks/useCriteriaResults.tsx:167
+msgid "other buildings."
+msgstr "other buildings."
+
 #: src/Components/Pages/Form/Survey.tsx:254
 #~ msgid "Other subsidized housing"
 #~ msgstr "Other subsidized housing"
@@ -1016,7 +1036,7 @@ msgstr "Phone number submitted"
 msgid "Please complete the unanswered questions before continuing."
 msgstr "Please complete the unanswered questions before continuing."
 
-#: src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx:66
+#: src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx:67
 msgid "Please confirm your address"
 msgstr "Please confirm your address"
 
@@ -1057,7 +1077,7 @@ msgstr "Print coverage"
 msgid "Privacy policy"
 msgstr "Privacy policy"
 
-#: src/Components/Footer/Footer.tsx:36
+#: src/Components/Footer/Footer.tsx:39
 msgid "Privacy Policy"
 msgstr "Privacy Policy"
 
@@ -1152,7 +1172,7 @@ msgstr "Remember, your building has {0, plural, one {# apartment} other {# apart
 msgid "Rent Amount"
 msgstr "Rent Amount"
 
-#: src/Components/TopBar/TopBar.tsx:53
+#: src/Components/TopBar/TopBar.tsx:55
 msgid "Rent increase calculator"
 msgstr "Rent increase calculator"
 
@@ -1184,7 +1204,7 @@ msgstr "Residential Tenants Guide"
 msgid "Result"
 msgstr "Result"
 
-#: src/Components/Pages/Results/Results.tsx:379
+#: src/Components/Pages/Results/Results.tsx:381
 msgid "Results are based on publicly available data about your building and the answers you provided. This does not constitute legal advice."
 msgstr "Results are based on publicly available data about your building and the answers you provided. This does not constitute legal advice."
 
@@ -1196,7 +1216,7 @@ msgstr "Sample image of blank rent stabilized lease"
 msgid "Save your result to your phone"
 msgstr "Save your result to your phone"
 
-#: src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx:85
+#: src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx:86
 msgid "Search new address"
 msgstr "Search new address"
 
@@ -1306,7 +1326,7 @@ msgstr "Tenants have the right to live in a safe, sanitary, and well-maintained 
 msgid "Terms of use"
 msgstr "Terms of use"
 
-#: src/Components/Footer/Footer.tsx:44
+#: src/Components/Footer/Footer.tsx:47
 msgid "Terms of Use"
 msgstr "Terms of Use"
 
@@ -1339,7 +1359,7 @@ msgstr "The building must not be part of NYCHA, PACT/RAD, or other subsidized ho
 msgid "The Good Cause law establishes a Reasonable Rent Increase, which is set every year at the rate of inflation plus 5%, with a maximum of 10% total. As of ${0}, the rate of inflation for New York City is ${CPI}%, meaning that the current local Reasonable Rent Increase is ${1}%."
 msgstr "The Good Cause law establishes a Reasonable Rent Increase, which is set every year at the rate of inflation plus 5%, with a maximum of 10% total. As of ${0}, the rate of inflation for New York City is ${CPI}%, meaning that the current local Reasonable Rent Increase is ${1}%."
 
-#: src/Components/Footer/Footer.tsx:22
+#: src/Components/Footer/Footer.tsx:25
 msgid "The information on this website does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing."
 msgstr "The information on this website does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing."
 
@@ -1373,7 +1393,7 @@ msgstr "The owner of the building may be different than the person listed on you
 msgid "The state housing agency must publish each year’s Reasonable Rent Increase by August. This year the maximum amount your landlord can increase your rent by is ${increase_pct}%."
 msgstr "The state housing agency must publish each year’s Reasonable Rent Increase by August. This year the maximum amount your landlord can increase your rent by is ${increase_pct}%."
 
-#: src/Components/Pages/Results/Results.tsx:434
+#: src/Components/Pages/Results/Results.tsx:441
 msgid "There {steps, plural, one {is # thing} other {are # things}} you need to verify to confirm your coverage"
 msgstr "There {steps, plural, one {is # thing} other {are # things}} you need to verify to confirm your coverage"
 
@@ -1507,11 +1527,11 @@ msgstr "We are unable to directly link to specific documents for properties in S
 msgid "We check for NYCHA, Mitchell-Lama, HDFC, LIHTC, Project Section 8, and various HPD and HUD programs. If you know the public data is incorrect, use these tips to guide your answer:"
 msgstr "We check for NYCHA, Mitchell-Lama, HDFC, LIHTC, Project Section 8, and various HPD and HUD programs. If you know the public data is incorrect, use these tips to guide your answer:"
 
-#: src/Components/Pages/Results/Results.tsx:443
+#: src/Components/Pages/Results/Results.tsx:450
 msgid "We need to confirm if your apartment is rent stabilized"
 msgstr "We need to confirm if your apartment is rent stabilized"
 
-#: src/Components/Pages/Results/Results.tsx:468
+#: src/Components/Pages/Results/Results.tsx:475
 msgid "We need to confirm if your landlord owns more than 10 apartments"
 msgstr "We need to confirm if your landlord owns more than 10 apartments"
 
@@ -1532,7 +1552,7 @@ msgstr "We will never call you or share your phone number. We may text you later
 msgid "We’ll text you once a year to learn about your housing conditions. We’ll use your answers to better advocate for your rights."
 msgstr "We’ll text you once a year to learn about your housing conditions. We’ll use your answers to better advocate for your rights."
 
-#: src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx:68
+#: src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx:69
 msgid "We’ll use publicly available information about your building to help learn if you’re covered."
 msgstr "We’ll use publicly available information about your building to help learn if you’re covered."
 
@@ -1681,7 +1701,7 @@ msgstr "You reported that your rent is {0}."
 msgid "You told us that that you live subsidized housing. If your building is subsidized then you are not covered by Good Cause Eviction law because you should already have important tenant protections associated with your building’s subsidy."
 msgstr "You told us that that you live subsidized housing. If your building is subsidized then you are not covered by Good Cause Eviction law because you should already have important tenant protections associated with your building’s subsidy."
 
-#: src/Components/Pages/Results/Results.tsx:450
+#: src/Components/Pages/Results/Results.tsx:457
 msgid "You told us that you are unsure if you are rent stabilized. If your apartment is rent stabilized, you are not covered by Good Cause Eviction law, but rent stabilized protections are even stronger than the Good Cause Eviction law."
 msgstr "You told us that you are unsure if you are rent stabilized. If your apartment is rent stabilized, you are not covered by Good Cause Eviction law, but rent stabilized protections are even stronger than the Good Cause Eviction law.======="
 
@@ -1731,10 +1751,13 @@ msgstr "Your building has ${0} apartments and you reported that your landlord do
 msgid "Your building has no new recorded certificate of occupancy since 2009."
 msgstr "Your building has no new recorded certificate of occupancy since 2009."
 
-#. placeholder {1}: relatedProperties ? ( <Trans> publicly available data sources indicate that your landlord may be associated with {formatNumber(relatedProperties)} </Trans> ) : ( <Trans>your landlord may own</Trans> )
+#: src/hooks/useCriteriaResults.tsx:158
+msgid "Your building has only {pluralApartments}, but"
+msgstr "Your building has only {pluralApartments}, but"
+
 #: src/hooks/useCriteriaResults.tsx:157
-msgid "Your building has only {pluralApartments}, but{1} other buildings. <0>Find your landlord’s other buildings</0>"
-msgstr "Your building has only {pluralApartments}, but{1} other buildings. <0>Find your landlord’s other buildings</0>"
+#~ msgid "Your building has only {pluralApartments}, but{1} other buildings. <0>Find your landlord’s other buildings</0>"
+#~ msgstr "Your building has only {pluralApartments}, but{1} other buildings. <0>Find your landlord’s other buildings</0>"
 
 #. placeholder {0}: activeJ51 ? "421a" : "J51"
 #: src/hooks/useCriteriaResults.tsx:357

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -31,8 +31,8 @@ msgstr ""
 #~ msgid "\"How to find out if your apartment is rent stabilized"
 #~ msgstr "\"How to find out if your apartment is rent stabilized"
 
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:166
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:245
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:165
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:244
 msgid "(123) 456-7890"
 msgstr "(123) 456-7890"
 
@@ -46,7 +46,7 @@ msgstr "(Tu renta mensual actual {0} + {increase_pct}%)"
 msgid "{0} "
 msgstr "{0} "
 
-#: src/hooks/useCriteriaResults.tsx:258
+#: src/hooks/useCriteriaResults.tsx:263
 msgid "{bedrooms} bedroom"
 msgstr "{bedrooms} cuarto"
 
@@ -55,7 +55,7 @@ msgid "{docType}"
 msgstr "{docType}"
 
 #: src/Components/Pages/PortfolioSize/PortfolioSize.tsx:337
-#: src/hooks/useCriteriaResults.tsx:104
+#: src/hooks/useCriteriaResults.tsx:107
 msgid "{unitsres, plural, one {# apartment} other {# apartments}}"
 msgstr "{unitsres, plural, one {# departamento} other {# departamentos}}"
 
@@ -83,27 +83,27 @@ msgstr "<0>Consejo:</0> Si en alguno de los documentos que se indican a continua
 msgid "<0>Tip:</0> We recommend doing the following research on a desktop computer. If you have not already, please watch the video, above, for step-by-step instructions on how to complete Steps 1 and 2."
 msgstr "<0>Consejo:</0> Recomendamos realizar la siguiente investigación en una computadora de escritorio. Si aún no lo ha hecho, vea el video anterior para obtener instrucciones paso a paso sobre cómo completar los pasos 1 y 2."
 
-#: src/Components/Pages/Results/Results.tsx:570
+#: src/Components/Pages/Results/Results.tsx:574
 msgid "<0>You are</0> <1>likely covered</1> by Good Cause Eviction"
 msgstr "<1>Es probable que</1> <0>usted esté</0> <1>cubierto</1> por el desalojo por justa causa."
 
-#: src/Components/Pages/Results/Results.tsx:551
+#: src/Components/Pages/Results/Results.tsx:555
 msgid "<0>You are</0> <1>likely not covered</1> <2/>by Good Cause Eviction"
 msgstr "<1>Es probable que no</1> <0>esté</0> <1>cubierto</1> <2/>por el desalojo por justa causa."
 
-#: src/Components/Pages/Results/Results.tsx:542
+#: src/Components/Pages/Results/Results.tsx:546
 msgid "<0>You</0> <1>might be covered</1> by Good Cause Eviction"
 msgstr "<1>Es posible que</1> <0>usted</0> <1>esté protegido</1> por la expulsión por justa causa."
 
-#: src/Components/Pages/Results/Results.tsx:579
+#: src/Components/Pages/Results/Results.tsx:583
 msgid "<0>Your apartment is part of</0> <1>NYCHA or PACT/RAD</1> which provides stronger protections than Good Cause Eviction"
 msgstr "<0>Tu departamento forma parte de</0> <1>NYCHA o PACT/RAD</1>, que ofrecen protecciones más sólidas que el desalojo por justa causa."
 
-#: src/Components/Pages/Results/Results.tsx:561
+#: src/Components/Pages/Results/Results.tsx:565
 msgid "<0>Your apartment is</0> <1>rent stabilized</1> which provides stronger protections than Good Cause Eviction"
 msgstr "<0>Tu departamento tiene</0> <1>renta estabilizada</1>, lo que te brinda mayor protección que la expulsión por justa causa."
 
-#: src/Components/Pages/Results/Results.tsx:590
+#: src/Components/Pages/Results/Results.tsx:594
 msgid "<0>Your building is</0> <1>subsidized</1> which provides existing eviction protections"
 msgstr "<0>Tu edificio está</0> <1>subsidiado</1>, lo que te brinda protección contra el desalojo."
 
@@ -147,11 +147,11 @@ msgstr "5. ¿Tu arrendador vive en el edificio?"
 msgid "6. Does your landlord own more than 10 apartments across multiple buildings?"
 msgstr "6. ¿Tu arrendador es dueño de más de 10 departamentos en varios edificios?"
 
-#: src/hooks/useCriteriaResults.tsx:408
+#: src/hooks/useCriteriaResults.tsx:416
 msgid "a co-op"
 msgstr "una cooperativa"
 
-#: src/hooks/useCriteriaResults.tsx:405
+#: src/hooks/useCriteriaResults.tsx:413
 msgid "a condo"
 msgstr "un departamento"
 
@@ -181,7 +181,7 @@ msgstr "Dirección"
 
 #: src/Components/Pages/PortfolioSize/PortfolioSize.tsx:277
 #: src/Components/Pages/RentStabilization/RentStabilization.tsx:144
-#: src/Components/Pages/Results/Results.tsx:497
+#: src/Components/Pages/Results/Results.tsx:501
 msgid "Adjust survey answers"
 msgstr "Ajustar las respuestas de la encuesta"
 
@@ -189,7 +189,7 @@ msgstr "Ajustar las respuestas de la encuesta"
 msgid "Agreement"
 msgstr "Acuerdo"
 
-#: src/hooks/useCriteriaResults.tsx:353
+#: src/hooks/useCriteriaResults.tsx:361
 msgid "all apartments in your building are registered as rent stabilized."
 msgstr "Todos los departamentos de su edificio están registrados como de renta estabilizada."
 
@@ -215,11 +215,11 @@ msgid "Attend a walk-in Clinic hosted by the Met Council on Housing"
 msgstr "Asista a una clínica sin cita previa organizada por el Consejo Metropolitano de Vivienda."
 
 #: src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx:114
-#: src/Components/Pages/Form/Survey.tsx:359
+#: src/Components/Pages/Form/Survey.tsx:362
 msgid "Back"
 msgstr "Atrás"
 
-#: src/Components/Header/Header.tsx:37
+#: src/Components/Header/Header.tsx:39
 msgid "Back to Result"
 msgstr "Volver a los resultados"
 
@@ -235,15 +235,15 @@ msgstr "Basándonos en los datos del sitio web {wowLink}, recopilamos una lista 
 msgid "Based on data from the website {wowLink}, we have gathered a list of properties that the owner of your building may be associated with. For each property, we have included links to important real estate transaction documents."
 msgstr "Basándonos en los datos del sitio web {wowLink}, hemos recopilado una lista de propiedades que podrían estar relacionadas con el propietario de su edificio. Para cada propiedad, hemos incluido enlaces a documentos importantes relacionados con transacciones inmobiliarias."
 
-#: src/Components/Pages/Form/Survey.tsx:541
+#: src/Components/Pages/Form/Survey.tsx:544
 msgid "Because your building has fewer than 6 units and was built after 1974, it is very unlikely that your apartment is rent stabilized. Additionally, based on publicly available data, no rent stabilized apartments were registered in your building in recent years."
 msgstr "Dado que su edificio tiene menos de 6 unidades y fue construido después de 1974, es muy poco probable que su departamento tenga renta estabilizada. Además, según los datos disponibles públicamente, en los últimos años no se ha registrado ningún departamento con renta estabilizada en su edificio."
 
-#: src/Components/Pages/Form/Survey.tsx:564
+#: src/Components/Pages/Form/Survey.tsx:567
 msgid "Because your building has fewer than 6 units it is very unlikely that your apartment is rent stabilized. Additionally, based on publicly available, no rent stabilized apartments were registered in your building in recent years."
 msgstr "Dado que su edificio tiene menos de 6 unidades, es muy poco probable que su departamento tenga renta estabilizada. Además, según la información disponible públicamente, en los últimos años no se ha registrado ningún departamento con renta estabilizada en su edificio."
 
-#: src/Components/Pages/Form/Survey.tsx:552
+#: src/Components/Pages/Form/Survey.tsx:555
 msgid "Because your building was built after 1974 and is not part of 421a or J51 tax incentive programs, it is very unlikely that your apartment is rent stabilized. Additionally, based on publicly available, no rent stabilized apartments were registered in your building in recent years."
 msgstr "Dado que su edificio fue construido después de 1974 y no forma parte de los programas de incentivos fiscales 421a o J51, es muy poco probable que su departamento tenga renta estabilizada. Además, según la información disponible públicamente, en los últimos años no se ha registrado ningún departamento con renta estabilizada en su edificio."
 
@@ -284,23 +284,23 @@ msgstr "Revisa la renovación más reciente de tu contrato de arrendamiento."
 msgid "City data indicates that there aren’t any residential units at this address."
 msgstr "Los datos municipales indican que no hay ninguna vivienda en esta dirección."
 
-#: src/hooks/useCriteriaResults.tsx:420
+#: src/hooks/useCriteriaResults.tsx:428
 msgid "classified as a health facility"
 msgstr "clasificado como centro de salud"
 
-#: src/hooks/useCriteriaResults.tsx:414
+#: src/hooks/useCriteriaResults.tsx:422
 msgid "classified as a hotel"
 msgstr "clasificado como hotel"
 
-#: src/hooks/useCriteriaResults.tsx:417
+#: src/hooks/useCriteriaResults.tsx:425
 msgid "classified as a religious facility"
 msgstr "clasificado como centro religioso"
 
-#: src/hooks/useCriteriaResults.tsx:411
+#: src/hooks/useCriteriaResults.tsx:419
 msgid "classified as an educational building"
 msgstr "clasificado como edificio educativo"
 
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:276
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:275
 msgid "Close"
 msgstr "Cerrar"
 
@@ -312,11 +312,11 @@ msgstr "Cerrar modal"
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: src/Components/Pages/Results/Results.tsx:631
+#: src/Components/Pages/Results/Results.tsx:635
 msgid "Copied"
 msgstr "Copiado"
 
-#: src/Components/Pages/Results/Results.tsx:623
+#: src/Components/Pages/Results/Results.tsx:627
 msgid "Copy goodcausenyc.org"
 msgstr "Copiar goodcausenyc.org"
 
@@ -346,8 +346,8 @@ msgstr "Elegible"
 msgid "Email coverage"
 msgstr "Cobertura de correo electrónico"
 
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:168
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:247
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:167
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:246
 msgid "Enter a valid phone number"
 msgstr "Ingresa un número de teléfono válido."
 
@@ -383,7 +383,7 @@ msgstr "No firmar la renovación del contrato de arrendamiento o no permitir el 
 msgid "Fair Housing NYC"
 msgstr "Vivienda justa en Nueva York"
 
-#: src/Components/Pages/Form/Survey.tsx:380
+#: src/Components/Pages/Form/Survey.tsx:383
 msgid "FAQs to help guide your answer"
 msgstr "Preguntas frecuentes para ayudarle a encontrar la respuesta"
 
@@ -399,7 +399,7 @@ msgstr "Formulario de comentarios"
 msgid "Fill out the request form"
 msgstr "Llene el formulario de solicitud."
 
-#: src/Components/Pages/Results/Results.tsx:490
+#: src/Components/Pages/Results/Results.tsx:494
 msgid "Find other buildings your landlord owns"
 msgstr "Busca otros edificios que sean propiedad de tu arrendador."
 
@@ -414,9 +414,9 @@ msgid "Find out if you’re covered by Good Cause"
 msgstr "Averigüe si está cubierto por una justa causa"
 
 #: src/Components/Pages/RentStabilization/RentStabilization.tsx:42
-#: src/Components/Pages/Results/Results.tsx:467
+#: src/Components/Pages/Results/Results.tsx:469
 #: src/Components/Pages/TenantRights/TenantRights.tsx:44
-#: src/hooks/useCriteriaResults.tsx:321
+#: src/hooks/useCriteriaResults.tsx:329
 msgid "Find out if your apartment is rent stabilized"
 msgstr "Averigüe si su departamento tiene renta estabilizada."
 
@@ -424,13 +424,13 @@ msgstr "Averigüe si su departamento tiene renta estabilizada."
 msgid "Find out if your landlord owns other buildings"
 msgstr "Averigüe si su arrendador es propietario de otros edificios."
 
-#: src/hooks/useCriteriaResults.tsx:169
+#: src/hooks/useCriteriaResults.tsx:174
 msgid "Find your landlord’s other buildings"
 msgstr ""
 
 #. placeholder {0}: bedrooms === "STUDIO" ? ( <Trans>studio</Trans> ) : ( <Trans>{bedrooms} bedroom</Trans> )
 #. placeholder {1}: formatMoney(RENT_CUTOFFS[bedrooms], 0)
-#: src/hooks/useCriteriaResults.tsx:253
+#: src/hooks/useCriteriaResults.tsx:258
 msgid "For a {0}, the monthly total rent must be less than {1}"
 msgstr "Para un {0}, el alquiler mensual total debe ser inferior a {1}"
 
@@ -455,7 +455,7 @@ msgid "Get started"
 msgstr "Comenzar"
 
 #. placeholder {0}: bldgData.unitsres
-#: src/Components/Pages/Results/Results.tsx:482
+#: src/Components/Pages/Results/Results.tsx:484
 msgid "Good Cause Eviction law only covers tenants whose landlord owns more than 10 apartments. Your building has only {0} apartments, but your landlord may own other buildings."
 msgstr "La ley de desalojo por justa causa solo cubre a los inquilinos cuyo propietario posea más de 10 departamentos. Su edificio solo tiene {0} departamentos, pero es posible que su propietario posea otros edificios."
 
@@ -489,7 +489,7 @@ msgid "Has your landlord raised your rent? Is your landlord refusing to do basic
 msgstr "¿Tu arrendador te ha subido el alquiler? ¿Tu arrendador se niega a hacer reparaciones básicas? ¿Te preocupa que te desalojen o no te renueven el contrato?"
 
 #: src/Components/Pages/PortfolioSize/PortfolioSize.tsx:276
-#: src/Components/Pages/Results/Results.tsx:496
+#: src/Components/Pages/Results/Results.tsx:500
 msgid "Have you learned something new?"
 msgstr "¿Has aprendido algo nuevo?"
 
@@ -543,19 +543,19 @@ msgstr "Cómo determinamos su cobertura"
 msgid "I'm not sure"
 msgstr "No estoy seguro."
 
-#: src/hooks/useCriteriaResults.tsx:188
+#: src/hooks/useCriteriaResults.tsx:193
 msgid "If the building has 10 or fewer apartments, the landlord must not also live in it."
 msgstr "Si el edificio tiene 10 o menos departamentos, el propietario no debe vivir también en él."
 
-#: src/hooks/useCriteriaResults.tsx:585
+#: src/hooks/useCriteriaResults.tsx:593
 msgid "If those sources are correct, then you may already have stronger tenant protections than other subsidized housing programs."
 msgstr "Si esas fuentes son correctas, es posible que ya cuentes con protecciones para inquilinos más sólidas que otras de los programas de vivienda subsidiada."
 
-#: src/hooks/useCriteriaResults.tsx:608
+#: src/hooks/useCriteriaResults.tsx:616
 msgid "If those sources are correct, you may have existing tenant protections through NYCHA or PACT/RAD."
 msgstr "Si esas fuentes son correctas, es posible que usted cuente con protecciones para inquilinos a través de NYCHA o PACT/RAD."
 
-#: src/hooks/useCriteriaResults.tsx:665
+#: src/hooks/useCriteriaResults.tsx:673
 msgid "If those sources are correct, you may have existing tenant protections through your building’s subsidy program."
 msgstr "Si esas fuentes son correctas, es posible que usted cuente con protecciones para inquilinos a través del programa de subsidios de su edificio."
 
@@ -563,7 +563,7 @@ msgstr "Si esas fuentes son correctas, es posible que usted cuente con proteccio
 #~ msgid "If you applied for your apartment through \"NYC Housing Connect,\" your building is very likely subsidized, and you should select the option: <0>\"Other subsidized housing\"</0>"
 #~ msgstr "If you applied for your apartment through \"NYC Housing Connect,\" your building is very likely subsidized, and you should select the option: <0>\"Other subsidized housing\"</0>"
 
-#: src/Components/Pages/Form/Survey.tsx:398
+#: src/Components/Pages/Form/Survey.tsx:401
 msgid "If you applied for your apartment through \"NYC Housing Connect,\" your building is very likely subsidized, and you should select the option: <0>“Yes, Mitchell-Lama, HDFC, or other”</0>"
 msgstr "Si solicitó su departamento a través de «NYC Housing Connect», es muy probable que su edificio esté subsidiado, por lo que debe seleccionar la opción: <0>«Sí, Mitchell-Lama, HDFC u otro».</0>"
 
@@ -588,11 +588,11 @@ msgstr "Si usted es familiar directo de un inquilino con renta estabilizada y ha
 #~ msgid "If you know that your building is part of Low-Income Housing Tax Credit (LIHTC) program, select the option: <0>\"Other subsidized housing\"</0>"
 #~ msgstr "If you know that your building is part of Low-Income Housing Tax Credit (LIHTC) program, select the option: <0>\"Other subsidized housing\"</0>"
 
-#: src/Components/Pages/Form/Survey.tsx:407
+#: src/Components/Pages/Form/Survey.tsx:410
 msgid "If you know that your building is part of Low-Income Housing Tax Credit (LIHTC) program, select the option: <0>“Yes, Mitchell-Lama, HDFC, or other”</0> "
 msgstr "Si sabe que su edificio forma parte del programa de Crédito Fiscal para Viviendas de Bajos Ingresos (LIHTC), seleccione la opción: <0>«Sí, Mitchell-Lama, HDFC u otro</0> ». "
 
-#: src/Components/Pages/Form/Survey.tsx:416
+#: src/Components/Pages/Form/Survey.tsx:419
 msgid "If you know that your building is part of public housing (NYCHA or PACT-RAD), select: <0>\"NYCHA or PACT/RAD\"</0>"
 msgstr "Si sabe que su edificio forma parte de una vivienda pública (NYCHA o PACT-RAD), seleccione: <0> «NYCHA o PACT/RAD».</0>"
 
@@ -600,7 +600,7 @@ msgstr "Si sabe que su edificio forma parte de una vivienda pública (NYCHA o PA
 #~ msgid "If you know that your building receives 421a or J51 tax abatement, select the option: <0>\"None of the above\"</0>"
 #~ msgstr "If you know that your building receives 421a or J51 tax abatement, select the option: <0>\"None of the above\"</0>"
 
-#: src/Components/Pages/Form/Survey.tsx:424
+#: src/Components/Pages/Form/Survey.tsx:427
 msgid "If you know that your building receives 421a or J51 tax abatement, select the option:<0>“No, my building is not subsidized”</0>"
 msgstr "Si sabe que su edificio recibe una reducción fiscal 421a o J51, seleccione la opción:<0>«No, mi edificio no está subvencionado».</0>"
 
@@ -616,7 +616,7 @@ msgstr "Si vives en la ciudad de Nueva York y no estás cubierto por la ley de d
 msgid "If you live outside of NYC"
 msgstr "Si vives fuera de Nueva York"
 
-#: src/Components/Pages/Form/Survey.tsx:441
+#: src/Components/Pages/Form/Survey.tsx:444
 msgid "If you use a voucher that covers some or all of your rent, and you can use that voucher in another apartment if you move, select the option: <0>“No, my building is not subsidized”</0>"
 msgstr "Si utiliza un vale que cubre parte o la totalidad de su renta, y puede utilizar ese vale en otro departamento si se muda, seleccione la opción: <0>«No, mi edificio no está subsidiado».</0>"
 
@@ -652,7 +652,7 @@ msgstr "Si tu arrendador se niega a renovar tu contrato de alquiler, te dice que
 msgid "If your landlord takes you to court, you can raise a “Good Cause” defense. Your landlord would then have to demonstrate to the judge that they raised the rent because of increased costs (taxes, maintenance costs, etc.) or be forced to lower the increase."
 msgstr "Si su arrendador lo lleva a juicio, usted puede presentar una defensa por «justa causa». En ese caso, su arrendador tendría que demostrar ante el juez que aumentó el alquiler debido al incremento de los costos (impuestos, gastos de mantenimiento, etc.) o se vería obligado a reducir el aumento."
 
-#: src/Components/Pages/Form/Survey.tsx:478
+#: src/Components/Pages/Form/Survey.tsx:481
 #: src/Components/Pages/RentStabilization/RentStabilization.tsx:107
 msgid "If your most recent lease renewal <0>looks like this</0>, then your apartment is likely rent stabilized."
 msgstr "Si la renovación más reciente de su contrato de arrendamiento <0>se parece a esta</0>, es probable que su departamento tenga renta estabilizada."
@@ -696,19 +696,19 @@ msgstr "No apto"
 msgid "Invoke “Good Cause” to a judge"
 msgstr "Invocar «justa causa» ante un juez."
 
-#: src/Components/Pages/Form/Survey.tsx:657
+#: src/Components/Pages/Form/Survey.tsx:660
 msgid "is a Mitchell-Lama"
 msgstr "es un Mitchell-Lama"
 
-#: src/Components/Pages/Form/Survey.tsx:653
+#: src/Components/Pages/Form/Survey.tsx:656
 msgid "is an Article XI"
 msgstr "es un artículo XI"
 
-#: src/Components/Pages/Form/Survey.tsx:655
+#: src/Components/Pages/Form/Survey.tsx:658
 msgid "is part of an HPD subsidy program"
 msgstr "forma parte de un programa de subsidios del Departamento de Vivienda de Houston (HPD)."
 
-#: src/Components/Pages/Form/Survey.tsx:659
+#: src/Components/Pages/Form/Survey.tsx:662
 msgid "is part of NYCHA or PACT/RAD"
 msgstr "forma parte de NYCHA o PACT/RAD"
 
@@ -773,7 +773,7 @@ msgstr "Descubra cómo pueden ayudar las asociaciones de inquilinos."
 msgid "Learn if you’re covered <0/>by Good Cause <1/>Eviction law in NYC"
 msgstr "Averigüe si está cubierto <0/>por una justa causa <1/>Ley de desahucios en la ciudad de Nueva York"
 
-#: src/Components/Pages/Form/Survey.tsx:600
+#: src/Components/Pages/Form/Survey.tsx:603
 msgid "Learn more"
 msgstr "Más información"
 
@@ -871,7 +871,7 @@ msgstr "Cargando enlaces a documentos..."
 msgid "Loading your results..."
 msgstr "Cargando tus resultados..."
 
-#: src/hooks/useCriteriaResults.tsx:399
+#: src/hooks/useCriteriaResults.tsx:407
 msgid "manufactured housing"
 msgstr "vivienda prefabricada"
 
@@ -912,7 +912,7 @@ msgstr "Línea directa del Consejo Metropolitano de Vivienda"
 msgid "Met Council on Housing’s Rent Stabilization overview"
 msgstr "Resumen sobre la estabilización de rentas del Consejo Metropolitano de Vivienda"
 
-#: src/hooks/useCriteriaResults.tsx:402
+#: src/hooks/useCriteriaResults.tsx:410
 msgid "missing class information"
 msgstr "información sobre clases perdidas"
 
@@ -934,12 +934,12 @@ msgstr ""
 msgid "No"
 msgstr "No"
 
-#: src/hooks/useCriteriaResults.tsx:110
-#: src/hooks/useCriteriaResults.tsx:199
+#: src/hooks/useCriteriaResults.tsx:113
+#: src/hooks/useCriteriaResults.tsx:204
 msgid "No data available for the number of apartments in your building."
 msgstr "No hay datos disponibles sobre el número de departamentos en su edificio."
 
-#: src/Components/Pages/Form/Survey.tsx:529
+#: src/Components/Pages/Form/Survey.tsx:532
 msgid "No rent stabilized apartments were registered in your building in recent years, but based on the size and age of your building some of the apartments may still be rent stabilized."
 msgstr "En los últimos años no se han registrado apartamentos con renta estabilizada en su edificio, pero según el tamaño y la antigüedad del mismo, es posible que algunos apartamentos sigan teniendo renta estabilizada."
 
@@ -959,7 +959,7 @@ msgstr "Incumplimiento del pago del alquiler"
 msgid "Note"
 msgstr "Nota"
 
-#: src/Components/Pages/Form/Survey.tsx:432
+#: src/Components/Pages/Form/Survey.tsx:435
 msgid "Note: if your building is part of 421a or J51, your apartment should be rent stabilized"
 msgstr "Nota: si su edificio forma parte de los programas 421a o J51, el alquiler de su departamento debería estar estabilizado."
 
@@ -979,12 +979,12 @@ msgstr "Hoja informativa sobre la garantía de habitabilidad de los tribunales d
 msgid "NY Homes and Community Renewal eviction information"
 msgstr "Información sobre desalojos de NY Homes and Community Renewal"
 
-#: src/hooks/useCriteriaResults.tsx:618
+#: src/hooks/useCriteriaResults.tsx:626
 msgid "NYCHA and PACT/RAD apartments are not covered by Good Cause because they already have stronger tenant protections than Good Cause provides."
 msgstr "Los departamentos de NYCHA y PACT/RAD no están cubiertos por Good Cause porque ya cuentan con protecciones para los inquilinos más sólidas que las que ofrece justa causa."
 
-#: src/hooks/useCriteriaResults.tsx:531
-#: src/hooks/useCriteriaResults.tsx:557
+#: src/hooks/useCriteriaResults.tsx:539
+#: src/hooks/useCriteriaResults.tsx:565
 msgid "NYCHA and PACT/RAD apartments are not covered by Good Cause because they already have stronger tenant protections than Good Cause."
 msgstr "Los apartamentos de NYCHA y PACT/RAD no están cubiertos por la cláusula de justa causa, ya que cuentan con protecciones para los inquilinos más sólidas que las que ofrece dicha cláusula."
 
@@ -1004,7 +1004,7 @@ msgstr "Proyecto de Justicia en Vivienda Pública de NYLAG"
 msgid "Once you find the name of your building’s owner, remember it because you’ll need it in Step 2."
 msgstr "Una vez que encuentres el nombre del propietario de tu edificio, recuérdalo porque lo necesitarás en el paso 2."
 
-#: src/hooks/useCriteriaResults.tsx:167
+#: src/hooks/useCriteriaResults.tsx:170
 msgid "other buildings."
 msgstr "otros edificios."
 
@@ -1024,16 +1024,16 @@ msgstr "Hoja informativa sobre el Pacto"
 msgid "PACT Rights and Responsibilities Fact Sheet"
 msgstr "Hoja informativa sobre los derechos y responsabilidades del PACT"
 
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:244
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:243
 msgid "Phone number"
 msgstr "Número de teléfono"
 
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:165
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:164
 msgid "Phone number (optional)"
 msgstr "Número de teléfono (opcional)"
 
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:185
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:257
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:184
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:256
 msgid "Phone number submitted"
 msgstr "Número de teléfono enviado"
 
@@ -1106,25 +1106,25 @@ msgstr "Protecciones que tienen todos los inquilinos de la ciudad de Nueva York"
 msgid "Protections under Good Cause"
 msgstr "Protecciones por justa causa"
 
-#: src/hooks/useCriteriaResults.tsx:434
+#: src/hooks/useCriteriaResults.tsx:442
 msgid "Public data sources indicate that your building is {bldgTypeName}, and so is not covered by Good Cause Eviction."
 msgstr "Las fuentes de datos públicas indican que su edificio es {bldgTypeName}, por lo que no está cubierto por el desalojo por justa causa."
 
-#: src/hooks/useCriteriaResults.tsx:429
+#: src/hooks/useCriteriaResults.tsx:437
 msgid "Public data sources indicate that your building is not a condo, co-op, or other exempt category."
 msgstr "Las fuentes de datos públicas indican que su edificio no es un condominio, una cooperativa ni pertenece a ninguna otra categoría exenta."
 
-#: src/Components/Pages/Form/Survey.tsx:631
+#: src/Components/Pages/Form/Survey.tsx:634
 msgid "Publicly available data sources do not indicate that your building is part of a subsidized housing program."
 msgstr "Las fuentes de datos disponibles públicamente no indican que su edificio forme parte de un programa de vivienda subvencionada."
 
 #. placeholder {0}: formatNumber(rsUnits)
 #. placeholder {1}: formatNumber(bldgUnits)
-#: src/Components/Pages/Form/Survey.tsx:518
+#: src/Components/Pages/Form/Survey.tsx:521
 msgid "Publicly available data sources indicate that {0} of the {1} apartments in your building are registered as rent stabilized."
 msgstr "Las fuentes de datos disponibles públicamente indican que {0} de los {1} apartamentos de su edificio están registrados como de renta estabilizada."
 
-#: src/Components/Pages/Form/Survey.tsx:508
+#: src/Components/Pages/Form/Survey.tsx:511
 msgid "Publicly available data sources indicate that all apartments in your building are registered as rent stabilized."
 msgstr "Las fuentes de datos disponibles públicamente indican que todos los departamentos de su edificio están registrados como de renta estabilizada."
 
@@ -1137,21 +1137,21 @@ msgstr "Las fuentes de datos disponibles públicamente indican que hay {0} en su
 #~ msgid "Publicly available data sources indicate that your building {0}, which is considered subsidized housing."
 #~ msgstr "Publicly available data sources indicate that your building {0}, which is considered subsidized housing."
 
-#: src/Components/Pages/Form/Survey.tsx:618
+#: src/Components/Pages/Form/Survey.tsx:621
 msgid "Publicly available data sources indicate that your building <0/>, which is considered subsidized housing."
 msgstr "Las fuentes de datos disponibles públicamente indican que su edificio <0/>, que se considera vivienda subsidiada."
 
-#: src/Components/Pages/Form/Survey.tsx:606
+#: src/Components/Pages/Form/Survey.tsx:609
 msgid "Publicly available data sources indicate that your building is part of NYCHA."
 msgstr "Las fuentes de datos disponibles públicamente indican que su edificio forma parte de la NYCHA."
 
 #. placeholder {0}: active421a ? "421a" : "J51"
-#: src/Components/Pages/Form/Survey.tsx:495
+#: src/Components/Pages/Form/Survey.tsx:498
 msgid "Publicly available data sources indicate that your building receives the {0} tax incentive. This means your apartment is rent stabilized."
 msgstr "Las fuentes de datos disponibles públicamente indican que su edificio recibe el incentivo fiscal del  Programa de Estabilización de Rentas ( {0} ). Esto significa que su apartamento tiene renta estabilizada."
 
 #. placeholder {0}: formatNumber(relatedProperties)
-#: src/hooks/useCriteriaResults.tsx:160
+#: src/hooks/useCriteriaResults.tsx:163
 msgid "publicly available data sources indicate that your landlord may be associated with {0}"
 msgstr "Las fuentes de datos disponibles públicamente indican que su arrendador podría estar asociado con {0}"
 
@@ -1159,11 +1159,11 @@ msgstr "Las fuentes de datos disponibles públicamente indican que su arrendador
 msgid "Reach out to external resources"
 msgstr "Recurrir a recursos externos"
 
-#: src/Components/Pages/Form/Survey.tsx:649
+#: src/Components/Pages/Form/Survey.tsx:652
 msgid "receives a HUD Project-Based subsidy"
 msgstr "recibe un subsidio basado en proyectos del HUD"
 
-#: src/Components/Pages/Form/Survey.tsx:651
+#: src/Components/Pages/Form/Survey.tsx:654
 msgid "receives the Low-Income Housing Tax Credit (LIHTC)"
 msgstr "recibe el Crédito Fiscal para Viviendas de Bajos Ingresos (LIHTC)"
 
@@ -1185,7 +1185,7 @@ msgstr "Calculadora de aumento de renta"
 msgid "Rent stabilization"
 msgstr "Estabilización de rentas"
 
-#: src/hooks/useCriteriaResults.tsx:331
+#: src/hooks/useCriteriaResults.tsx:339
 msgid "Rent stabilized apartments are not covered by Good Cause Eviction because they already have stronger tenant protections than Good Cause."
 msgstr "Los departamentos con renta estabilizada no están cubiertos por el desalojo por justa causa, ya que cuentan con protecciones para los inquilinos más sólidas que las de la justa causa."
 
@@ -1229,7 +1229,7 @@ msgstr "Buscar nueva dirección"
 msgid "See if you are eligible for a free attorney in housing court"
 msgstr "Averigüe si reúne los requisitos para obtener un abogado gratuito en el tribunal de vivienda."
 
-#: src/Components/Pages/Form/Survey.tsx:364
+#: src/Components/Pages/Form/Survey.tsx:367
 msgid "See your results"
 msgstr "Vea sus resultados"
 
@@ -1253,8 +1253,8 @@ msgstr "Mostrando {visibleCount} de {totalCount} edificios que su arrendador pod
 msgid "Since your apartment is covered by Good Cause Eviction, there is a good chance other apartments in your building are covered as well. Organizing with your neighbors can help you assert your rights as a group."
 msgstr "Dado que su departamento está protegido por la ley de desalojo por justa causa, es muy probable que otros departamentos de su edificio también lo estén. Organizarse con sus vecinos puede ayudarle a hacer valer sus derechos como grupo."
 
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:191
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:263
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:190
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:262
 msgid "Something went wrong. Try again later."
 msgstr "Algo salió mal. Inténtalo de nuevo más tarde."
 
@@ -1266,7 +1266,7 @@ msgstr "La discriminación por fuente de ingresos es la práctica ilegal por par
 msgid "Stronger protections"
 msgstr "Protecciones más sólidas"
 
-#: src/hooks/useCriteriaResults.tsx:256
+#: src/hooks/useCriteriaResults.tsx:261
 msgid "studio"
 msgstr "estudio"
 
@@ -1274,14 +1274,14 @@ msgstr "estudio"
 msgid "Studio"
 msgstr "Estudio"
 
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:176
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:203
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:283
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:175
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:202
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:282
 msgid "Submit"
 msgstr "Enviar"
 
-#: src/hooks/useCriteriaResults.tsx:540
-#: src/hooks/useCriteriaResults.tsx:638
+#: src/hooks/useCriteriaResults.tsx:548
+#: src/hooks/useCriteriaResults.tsx:646
 msgid "Subsidized buildings are not covered by Good Cause Eviction because they already have similar, and sometimes stronger, existing tenant protections."
 msgstr "Los edificios subsidiados no están cubiertos por el desalojo por justa causa, ya que cuentan con protecciones similares, y en ocasiones más sólidas, para los inquilinos."
 
@@ -1335,7 +1335,7 @@ msgstr "Condiciones de uso"
 msgid "Terms of Use"
 msgstr "Condiciones de uso"
 
-#: src/hooks/useCriteriaResults.tsx:302
+#: src/hooks/useCriteriaResults.tsx:308
 msgid "The apartment must not be rent stabilized."
 msgstr "El departamento no debe tener renta estabilizada."
 
@@ -1343,18 +1343,18 @@ msgstr "El departamento no debe tener renta estabilizada."
 msgid "The best way to confirm the owner of your building is to review your building’s official real estate transaction documents and look for the owner’s signature. We have provided links to these documents, below."
 msgstr "La mejor manera de confirmar quién es el propietario de su edificio es revisar los documentos oficiales de transacción inmobiliaria del mismo y buscar la firma del propietario. A continuación, le proporcionamos enlaces a dichos documentos."
 
-#: src/hooks/useCriteriaResults.tsx:467
+#: src/hooks/useCriteriaResults.tsx:475
 msgid "The building must have received its certificate of occupancy before 2009."
 msgstr "El edificio debe haber recibido su certificado de ocupación antes de 2009."
 
-#: src/hooks/useCriteriaResults.tsx:390
+#: src/hooks/useCriteriaResults.tsx:398
 msgid "The building must not be a condo, co-op, or other exempt building types."
 msgstr "El edificio no debe ser un condominio, una cooperativa u otro tipo de edificio exento."
 
-#: src/hooks/useCriteriaResults.tsx:518
-#: src/hooks/useCriteriaResults.tsx:570
-#: src/hooks/useCriteriaResults.tsx:593
-#: src/hooks/useCriteriaResults.tsx:648
+#: src/hooks/useCriteriaResults.tsx:526
+#: src/hooks/useCriteriaResults.tsx:578
+#: src/hooks/useCriteriaResults.tsx:601
+#: src/hooks/useCriteriaResults.tsx:656
 msgid "The building must not be part of NYCHA, PACT/RAD, or other subsidized housing."
 msgstr "El edificio no debe formar parte de NYCHA, PACT/RAD u otras viviendas subvencionadas."
 
@@ -1368,7 +1368,7 @@ msgstr "La ley Good Cause establece un aumento razonable del alquiler, que se fi
 msgid "The information on this website does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing."
 msgstr "La información contenida en este sitio web no constituye asesoramiento jurídico y no debe utilizarse como sustituto del asesoramiento de un abogado calificado para asesorar sobre cuestiones legales relacionadas con la vivienda."
 
-#: src/hooks/useCriteriaResults.tsx:90
+#: src/hooks/useCriteriaResults.tsx:93
 msgid "The landlord of the building must own more than 10 apartments."
 msgstr "El propietario del edificio debe poseer más de 10 departamentos."
 
@@ -1431,7 +1431,7 @@ msgstr "Para estar cubierto por la ley, tu departamento debe cumplir varios requ
 msgid "To find other buildings your landlord might own, you can:"
 msgstr "Para encontrar otros edificios que pueda tener su propietario, puede:"
 
-#: src/Components/Pages/Form/Survey.tsx:374
+#: src/Components/Pages/Form/Survey.tsx:377
 msgid "To help guide your answer"
 msgstr "Para ayudarte a responder"
 
@@ -1495,16 +1495,16 @@ msgstr "Ver todos los documentos del secretario del condado de Richmond"
 msgid "View all documents in ACRIS"
 msgstr "Ver todos los documentos en ACRIS"
 
-#: src/Components/Pages/Form/Survey.tsx:473
-#: src/Components/Pages/Form/Survey.tsx:501
-#: src/Components/Pages/Form/Survey.tsx:591
-#: src/hooks/useCriteriaResults.tsx:99
-#: src/hooks/useCriteriaResults.tsx:230
-#: src/hooks/useCriteriaResults.tsx:311
-#: src/hooks/useCriteriaResults.tsx:316
-#: src/hooks/useCriteriaResults.tsx:440
-#: src/hooks/useCriteriaResults.tsx:489
-#: src/hooks/useCriteriaResults.tsx:511
+#: src/Components/Pages/Form/Survey.tsx:476
+#: src/Components/Pages/Form/Survey.tsx:504
+#: src/Components/Pages/Form/Survey.tsx:594
+#: src/hooks/useCriteriaResults.tsx:102
+#: src/hooks/useCriteriaResults.tsx:235
+#: src/hooks/useCriteriaResults.tsx:317
+#: src/hooks/useCriteriaResults.tsx:322
+#: src/hooks/useCriteriaResults.tsx:448
+#: src/hooks/useCriteriaResults.tsx:497
+#: src/hooks/useCriteriaResults.tsx:519
 msgid "View source"
 msgstr "Ver fuente"
 
@@ -1528,7 +1528,7 @@ msgstr "Visita JustFix"
 msgid "We are unable to directly link to specific documents for properties in Staten Island. Please view all documents for this property, and refer to the video above to learn how to identify the documents most likely to contain the owner's name and signature."
 msgstr "No podemos enlazar directamente con documentos específicos de propiedades en Staten Island. Consulte todos los documentos de esta propiedad y vea el video anterior para saber cómo identificar los documentos que más probablemente contengan el nombre y la firma del propietario."
 
-#: src/Components/Pages/Form/Survey.tsx:390
+#: src/Components/Pages/Form/Survey.tsx:393
 msgid "We check for NYCHA, Mitchell-Lama, HDFC, LIHTC, Project Section 8, and various HPD and HUD programs. If you know the public data is incorrect, use these tips to guide your answer:"
 msgstr "Verificamos los programas NYCHA, Mitchell-Lama, HDFC, LIHTC, Proyecto Sección 8 y varios programas HPD y HUD. Si sabe que los datos públicos son incorrectos, utilice estos consejos para orientar su respuesta:"
 
@@ -1536,7 +1536,7 @@ msgstr "Verificamos los programas NYCHA, Mitchell-Lama, HDFC, LIHTC, Proyecto Se
 msgid "We need to confirm if your apartment is rent stabilized"
 msgstr "Necesitamos confirmar si su departamento tiene renta estabilizada."
 
-#: src/Components/Pages/Results/Results.tsx:475
+#: src/Components/Pages/Results/Results.tsx:477
 msgid "We need to confirm if your landlord owns more than 10 apartments"
 msgstr "Necesitamos confirmar si su arrendador es propietario de más de 10 departamentos."
 
@@ -1544,8 +1544,8 @@ msgstr "Necesitamos confirmar si su arrendador es propietario de más de 10 depa
 msgid "We were unable to find relevant documents containing owner names and/or signatures for this building."
 msgstr "No hemos podido encontrar documentos relevantes que contengan los nombres y/o firmas de los propietarios de este edificio."
 
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:194
-#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:268
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:193
+#: src/Components/PhoneNumberCallout/PhoneNumberCallout.tsx:267
 msgid "We will never call you or share your phone number. We may text you later in the year to see how things are going. Opt-out at any time."
 msgstr "Nunca te llamaremos ni compartiremos tu número de teléfono. Es posible que te enviemos un mensaje de texto más adelante en el año para ver cómo van las cosas. Puedes darte de baja en cualquier momento."
 
@@ -1599,7 +1599,7 @@ msgstr "Sí, NYCHA / PACT-RAD"
 msgid "You are not covered by Good Cause because you have existing eviction protections through your building’s subsidy program"
 msgstr "No está cubierto por la justa causa porque ya cuenta con protecciones contra el desalojo a través del programa de subsidios de su edificio."
 
-#: src/hooks/useCriteriaResults.tsx:348
+#: src/hooks/useCriteriaResults.tsx:356
 msgid "you are not sure if your apartment is"
 msgstr "no estás seguro de si tu departamento es"
 
@@ -1631,23 +1631,23 @@ msgstr "Solo necesita encontrar el nombre o la firma del propietario de su edifi
 #. placeholder {0}: rentStabilized === "NO" ? ( <Trans>your apartment is not</Trans> ) : ( <Trans>you are not sure if your apartment is</Trans> )
 #. placeholder {2}: allUnitsRS ? ( <Trans> all apartments in your building are registered as rent stabilized. </Trans> ) : ( <Trans> your building receives the {activeJ51 ? "421a" : "J51"} tax incentive, which means your apartment should be rent stabilized. </Trans> )
 #. placeholder {3}: allUnitsRS ? wowLink : subsidyLink
-#: src/hooks/useCriteriaResults.tsx:343
+#: src/hooks/useCriteriaResults.tsx:351
 msgid "You reported that {0} rent stabilized, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that{2} {3}If those sources are correct, then you may already have stronger tenant protections than Good Cause Eviction provides. {guideLink}"
 msgstr "Usted informó que {0} tiene renta estabilizada, y estamos utilizando su respuesta como parte de nuestra evaluación de cobertura. Nota: las fuentes de datos disponibles públicamente indican que{2} {3}Si esas fuentes son correctas, es posible que ya cuente con protecciones para inquilinos más sólidas que las que ofrece Good Cause Eviction. {guideLink}"
 
-#: src/hooks/useCriteriaResults.tsx:369
+#: src/hooks/useCriteriaResults.tsx:377
 msgid "You reported that you are not sure if your apartment is rent stabilized. {guideLink}"
 msgstr "Usted informó que no está seguro de si su departamento tiene renta estabilizada. {guideLink}"
 
-#: src/hooks/useCriteriaResults.tsx:367
+#: src/hooks/useCriteriaResults.tsx:375
 msgid "You reported that your apartment is not rent stabilized."
 msgstr "Usted informó que su departamento no tiene renta estabilizada."
 
-#: src/hooks/useCriteriaResults.tsx:337
+#: src/hooks/useCriteriaResults.tsx:345
 msgid "You reported that your apartment is rent stabilized."
 msgstr "Usted informó que su departamento tiene renta estabilizada."
 
-#: src/hooks/useCriteriaResults.tsx:601
+#: src/hooks/useCriteriaResults.tsx:609
 msgid "You reported that your building is not part of any subsidized housing programs, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building is part of NYCHA or PACT/RAD."
 msgstr "Usted informó que su edificio no forma parte de ningún programa de vivienda subsidiada, y estamos utilizando su respuesta como parte de nuestra evaluación de cobertura. Nota: las fuentes de datos disponibles públicamente indican que su edificio forma parte de NYCHA o PACT/RAD."
 
@@ -1655,7 +1655,7 @@ msgstr "Usted informó que su edificio no forma parte de ningún programa de viv
 #~ msgid "You reported that your building is not part of any subsidized housing programs, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building is part of NYCHA or PACT/RAD. {sourceLink} If those sources are correct, you may have existing tenant protections through NYCHA or PACT/RAD."
 #~ msgstr "You reported that your building is not part of any subsidized housing programs, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building is part of NYCHA or PACT/RAD. {sourceLink} If those sources are correct, you may have existing tenant protections through NYCHA or PACT/RAD."
 
-#: src/hooks/useCriteriaResults.tsx:548
+#: src/hooks/useCriteriaResults.tsx:556
 msgid "You reported that your building is not part of NYCHA, PACT/RAD, or other subsidized housing programs."
 msgstr "Usted informó que su edificio no forma parte de NYCHA, PACT/RAD ni otros programas de vivienda subsidiada."
 
@@ -1663,7 +1663,7 @@ msgstr "Usted informó que su edificio no forma parte de NYCHA, PACT/RAD ni otro
 #~ msgid "You reported that your building is not part of NYCHA, PACT/RAD, or other subsidized housing, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building {0} , which is considered subsidized housing. {sourceLink} If those sources are correct, you may have existing tenant protections through your building’s subsidy program."
 #~ msgstr "You reported that your building is not part of NYCHA, PACT/RAD, or other subsidized housing, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building {0} , which is considered subsidized housing. {sourceLink} If those sources are correct, you may have existing tenant protections through your building’s subsidy program."
 
-#: src/hooks/useCriteriaResults.tsx:656
+#: src/hooks/useCriteriaResults.tsx:664
 msgid "You reported that your building is not part of NYCHA, PACT/RAD, or other subsidized housing, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building <0/> , which is considered subsidized housing."
 msgstr "Usted informó que su edificio no forma parte de NYCHA, PACT/RAD ni de ningún otro programa de vivienda subsidiada, y estamos utilizando su respuesta como parte de nuestra evaluación de cobertura. Nota: las fuentes de datos disponibles públicamente indican que su edificio <0/>, que se considera vivienda subsidiada."
 
@@ -1675,16 +1675,16 @@ msgstr "Usted informó que su edificio no forma parte de NYCHA, PACT/RAD ni de n
 #~ msgid "You reported that your building is part of NYCHA or PACT/RAD, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building {0}, which is considered subsidized housing. {sourceLink} If those sources are correct, then your protections may be different than the protections of NYCHA or PACT/RAD."
 #~ msgstr "You reported that your building is part of NYCHA or PACT/RAD, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building {0}, which is considered subsidized housing. {sourceLink} If those sources are correct, then your protections may be different than the protections of NYCHA or PACT/RAD."
 
-#: src/hooks/useCriteriaResults.tsx:626
+#: src/hooks/useCriteriaResults.tsx:634
 msgid "You reported that your building is part of NYCHA or PACT/RAD, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building <0/>, which is considered subsidized housing. {sourceLink} If those sources are correct, then your protections may be different than the protections of NYCHA or PACT/RAD."
 msgstr "Usted informó que su edificio forma parte de NYCHA o PACT/RAD, y estamos utilizando su respuesta como parte de nuestra evaluación de cobertura. Nota: las fuentes de datos disponibles públicamente indican que su edificio <0/>, que se considera vivienda subsidiada. {sourceLink} Si esas fuentes son correctas, entonces sus protecciones pueden ser diferentes a las protecciones de NYCHA o PACT/RAD."
 
-#: src/hooks/useCriteriaResults.tsx:525
-#: src/hooks/useCriteriaResults.tsx:564
+#: src/hooks/useCriteriaResults.tsx:533
+#: src/hooks/useCriteriaResults.tsx:572
 msgid "You reported that your building is part of NYCHA or PACT/RAD."
 msgstr "Usted informó que su edificio forma parte de NYCHA o PACT/RAD."
 
-#: src/hooks/useCriteriaResults.tsx:578
+#: src/hooks/useCriteriaResults.tsx:586
 msgid "You reported that your building is subsidized, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building is part of NYCHA or PACT/RAD."
 msgstr "Usted informó que su edificio está subsidiado, y estamos utilizando su respuesta como parte de nuestra evaluación de cobertura. Nota: las fuentes de datos disponibles públicamente indican que su edificio forma parte de NYCHA o PACT/RAD."
 
@@ -1692,13 +1692,13 @@ msgstr "Usted informó que su edificio está subsidiado, y estamos utilizando su
 #~ msgid "You reported that your building is subsidized, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building is part of NYCHA or PACT/RAD. {sourceLink} If those sources are correct, then you may already have stronger tenant protections than other subsidized housing programs."
 #~ msgstr "You reported that your building is subsidized, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building is part of NYCHA or PACT/RAD. {sourceLink} If those sources are correct, then you may already have stronger tenant protections than other subsidized housing programs."
 
-#: src/hooks/useCriteriaResults.tsx:537
-#: src/hooks/useCriteriaResults.tsx:645
+#: src/hooks/useCriteriaResults.tsx:545
+#: src/hooks/useCriteriaResults.tsx:653
 msgid "You reported that your building is subsidized."
 msgstr "Usted informó que su edificio está subsidiado."
 
 #. placeholder {0}: formatMoney(rent, 0)
-#: src/hooks/useCriteriaResults.tsx:278
+#: src/hooks/useCriteriaResults.tsx:283
 msgid "You reported that your rent is {0}."
 msgstr "Usted informó que su renta es de {0}."
 
@@ -1714,49 +1714,49 @@ msgstr "Nos ha dicho que no está seguro de si su renta está estabilizada. Si s
 msgid "You’re not alone. Too many landlords care more about getting rich off our rent money than providing us with decent homes."
 msgstr "No estás solo. Demasiados propietarios se preocupan más por enriquecerse con el dinero de nuestro alquiler que por proporcionarnos viviendas dignas."
 
-#: src/hooks/useCriteriaResults.tsx:346
+#: src/hooks/useCriteriaResults.tsx:354
 msgid "your apartment is not"
 msgstr "tu departamento no es"
 
 #. placeholder {0}: formatNumber(unitsres)
-#: src/hooks/useCriteriaResults.tsx:149
+#: src/hooks/useCriteriaResults.tsx:152
 msgid "Your building has {0} apartments and you reported that your landlord does not own other buildings."
 msgstr "Su edificio tiene {0} apartamentos y usted ha informado de que su arrendador no es propietario de otros edificios."
 
 #. placeholder {0}: formatNumber(unitsres)
-#: src/hooks/useCriteriaResults.tsx:211
+#: src/hooks/useCriteriaResults.tsx:216
 msgid "Your building has {0} apartments and you reported that your landlord lives in the building."
 msgstr "Su edificio tiene {0} apartamentos y usted ha informado de que su arrendador vive en el edificio."
 
 #. placeholder {0}: formatNumber(unitsres)
-#: src/hooks/useCriteriaResults.tsx:144
-#: src/hooks/useCriteriaResults.tsx:206
+#: src/hooks/useCriteriaResults.tsx:147
+#: src/hooks/useCriteriaResults.tsx:211
 msgid "Your building has {0} apartments."
 msgstr "Tu edificio tiene {0} apartamentos."
 
 #. placeholder {0}: formatNumber(unitsres)
-#: src/hooks/useCriteriaResults.tsx:136
+#: src/hooks/useCriteriaResults.tsx:139
 msgid "Your building has {0} apartments. Additionally, your landlord may own other buildings in the city. {wowLink}"
 msgstr "Su edificio tiene {0} apartamentos. Además, es posible que su arrendador sea propietario de otros edificios en la ciudad. {wowLink}"
 
-#: src/hooks/useCriteriaResults.tsx:117
+#: src/hooks/useCriteriaResults.tsx:120
 msgid "Your building has {pluralApartments} and you reported that your landlord owns more than 10 apartments across multiple buildings. Additionally, your landlord may own other buildings in the city. {wowLink}"
 msgstr "Tu edificio tiene {pluralApartments} y has informado de que tu arrendador es propietario de más de 10 apartamentos en varios edificios. Además, es posible que tu arrendador sea propietario de otros edificios en la ciudad. {wowLink}"
 
-#: src/hooks/useCriteriaResults.tsx:126
+#: src/hooks/useCriteriaResults.tsx:129
 msgid "Your building has {unitsres, plural, one {# apartment} other {# apartments}}, and you reported that your landlord owns more than 10 apartments across multiple buildings."
 msgstr "Tu edificio tiene {unitsres, plural, one {# apartamentos} other {# apartamentos}}, y has informado de que tu arrendador es propietario de más de 10 apartamentos repartidos en varios edificios."
 
 #. placeholder {0}: formatNumber(unitsres)
-#: src/hooks/useCriteriaResults.tsx:219
+#: src/hooks/useCriteriaResults.tsx:224
 msgid "Your building has ${0} apartments and you reported that your landlord does not live in the building."
 msgstr "Su edificio tiene ${0} apartamentos y usted ha informado de que su arrendador no vive en el edificio."
 
-#: src/hooks/useCriteriaResults.tsx:476
+#: src/hooks/useCriteriaResults.tsx:484
 msgid "Your building has no new recorded certificate of occupancy since 2009."
 msgstr "Su edificio no tiene ningún certificado de ocupación nuevo registrado desde 2009."
 
-#: src/hooks/useCriteriaResults.tsx:158
+#: src/hooks/useCriteriaResults.tsx:161
 msgid "Your building has only {pluralApartments}, but"
 msgstr "Tu edificio solo tiene {pluralApartments}, pero"
 
@@ -1765,11 +1765,11 @@ msgstr "Tu edificio solo tiene {pluralApartments}, pero"
 #~ msgstr "Tu edificio solo tiene {pluralApartments}, pero{1} otros edificios. <0>Busca los otros edificios de tu propietario</0>."
 
 #. placeholder {0}: activeJ51 ? "421a" : "J51"
-#: src/hooks/useCriteriaResults.tsx:357
+#: src/hooks/useCriteriaResults.tsx:365
 msgid "your building receives the {0} tax incentive, which means your apartment should be rent stabilized."
 msgstr "Su edificio recibe el incentivo fiscal « {0} », lo que significa que su departamento debería tener un alquiler estabilizado."
 
-#: src/hooks/useCriteriaResults.tsx:480
+#: src/hooks/useCriteriaResults.tsx:488
 msgid "Your building was issued a certificate of occupancy on {latestCoDateFormatted}."
 msgstr "Su edificio obtuvo un certificado de ocupación el {latestCoDateFormatted}."
 
@@ -1793,7 +1793,7 @@ msgstr "Sus protecciones contra el desalojo"
 msgid "Your landlord can’t evict you based on your race, religion, gender, national origin, familial status, or disability. New York State law promises protection from discrimination, banning bias based on age, sexual orientation, and military status."
 msgstr "Tu arrendador no puede desalojarte por motivos de raza, religión, género, nacionalidad, situación familiar o discapacidad. La ley del estado de Nueva York garantiza protección contra la discriminación y prohíbe los prejuicios por motivos de edad, orientación sexual y condición militar."
 
-#: src/hooks/useCriteriaResults.tsx:165
+#: src/hooks/useCriteriaResults.tsx:168
 msgid "your landlord may own"
 msgstr "tu arrendador puede ser propietario de"
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -59,7 +59,7 @@ msgstr "{docType}"
 msgid "{unitsres, plural, one {# apartment} other {# apartments}}"
 msgstr "{unitsres, plural, one {# departamento} other {# departamentos}}"
 
-#: src/Components/TopBar/TopBar.tsx:29
+#: src/Components/TopBar/TopBar.tsx:31
 msgid "<0>By</0> <1>Housing Justice for All</1> <2>&</2> <3>JustFix</3>"
 msgstr "<0>Por</0> <1>Housing Justice for All</1> <2>y</2> <3>JustFix</3>"
 
@@ -83,27 +83,27 @@ msgstr "<0>Consejo:</0> Si en alguno de los documentos que se indican a continua
 msgid "<0>Tip:</0> We recommend doing the following research on a desktop computer. If you have not already, please watch the video, above, for step-by-step instructions on how to complete Steps 1 and 2."
 msgstr "<0>Consejo:</0> Recomendamos realizar la siguiente investigación en una computadora de escritorio. Si aún no lo ha hecho, vea el video anterior para obtener instrucciones paso a paso sobre cómo completar los pasos 1 y 2."
 
-#: src/Components/Pages/Results/Results.tsx:563
+#: src/Components/Pages/Results/Results.tsx:570
 msgid "<0>You are</0> <1>likely covered</1> by Good Cause Eviction"
 msgstr "<1>Es probable que</1> <0>usted esté</0> <1>cubierto</1> por el desalojo por justa causa."
 
-#: src/Components/Pages/Results/Results.tsx:544
+#: src/Components/Pages/Results/Results.tsx:551
 msgid "<0>You are</0> <1>likely not covered</1> <2/>by Good Cause Eviction"
 msgstr "<1>Es probable que no</1> <0>esté</0> <1>cubierto</1> <2/>por el desalojo por justa causa."
 
-#: src/Components/Pages/Results/Results.tsx:535
+#: src/Components/Pages/Results/Results.tsx:542
 msgid "<0>You</0> <1>might be covered</1> by Good Cause Eviction"
 msgstr "<1>Es posible que</1> <0>usted</0> <1>esté protegido</1> por la expulsión por justa causa."
 
-#: src/Components/Pages/Results/Results.tsx:572
+#: src/Components/Pages/Results/Results.tsx:579
 msgid "<0>Your apartment is part of</0> <1>NYCHA or PACT/RAD</1> which provides stronger protections than Good Cause Eviction"
 msgstr "<0>Tu departamento forma parte de</0> <1>NYCHA o PACT/RAD</1>, que ofrecen protecciones más sólidas que el desalojo por justa causa."
 
-#: src/Components/Pages/Results/Results.tsx:554
+#: src/Components/Pages/Results/Results.tsx:561
 msgid "<0>Your apartment is</0> <1>rent stabilized</1> which provides stronger protections than Good Cause Eviction"
 msgstr "<0>Tu departamento tiene</0> <1>renta estabilizada</1>, lo que te brinda mayor protección que la expulsión por justa causa."
 
-#: src/Components/Pages/Results/Results.tsx:583
+#: src/Components/Pages/Results/Results.tsx:590
 msgid "<0>Your building is</0> <1>subsidized</1> which provides existing eviction protections"
 msgstr "<0>Tu edificio está</0> <1>subsidiado</1>, lo que te brinda protección contra el desalojo."
 
@@ -181,7 +181,7 @@ msgstr "Dirección"
 
 #: src/Components/Pages/PortfolioSize/PortfolioSize.tsx:277
 #: src/Components/Pages/RentStabilization/RentStabilization.tsx:144
-#: src/Components/Pages/Results/Results.tsx:490
+#: src/Components/Pages/Results/Results.tsx:497
 msgid "Adjust survey answers"
 msgstr "Ajustar las respuestas de la encuesta"
 
@@ -214,7 +214,7 @@ msgstr "Cesión de arrendamientos y rentas"
 msgid "Attend a walk-in Clinic hosted by the Met Council on Housing"
 msgstr "Asista a una clínica sin cita previa organizada por el Consejo Metropolitano de Vivienda."
 
-#: src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx:113
+#: src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx:114
 #: src/Components/Pages/Form/Survey.tsx:359
 msgid "Back"
 msgstr "Atrás"
@@ -222,6 +222,10 @@ msgstr "Atrás"
 #: src/Components/Header/Header.tsx:37
 msgid "Back to Result"
 msgstr "Volver a los resultados"
+
+#: src/Components/Pages/Results/Results.tsx:406
+msgid "Back to survey"
+msgstr ""
 
 #: src/Components/Pages/PortfolioSize/PortfolioSize.tsx:203
 msgid "Based on data from the website {wowLink}, we gather a list of properties that the owner of your building may be associated with. For each property, we include links to important real estate transaction documents."
@@ -243,9 +247,13 @@ msgstr "Dado que su edificio tiene menos de 6 unidades, es muy poco probable que
 msgid "Because your building was built after 1974 and is not part of 421a or J51 tax incentive programs, it is very unlikely that your apartment is rent stabilized. Additionally, based on publicly available, no rent stabilized apartments were registered in your building in recent years."
 msgstr "Dado que su edificio fue construido después de 1974 y no forma parte de los programas de incentivos fiscales 421a o J51, es muy poco probable que su departamento tenga renta estabilizada. Además, según la información disponible públicamente, en los últimos años no se ha registrado ningún departamento con renta estabilizada en su edificio."
 
-#: src/Components/Footer/Footer.tsx:64
+#: src/Components/Footer/Footer.tsx:67
 msgid "By <0>Housing Justice for All</0> & <1>JustFix</1>"
 msgstr "Por <0>Housing Justice for All</0> y <1>JustFix</1>"
+
+#: src/Components/Pages/RentCalculator/RentCalculator.tsx:86
+msgid "Calculate"
+msgstr ""
 
 #: src/Components/Pages/Home/Home.tsx:118
 msgid "Calculate your max rent increase."
@@ -272,7 +280,7 @@ msgstr "Revisa la renovación de tu contrato de alquiler."
 msgid "Check your most recent lease renewal"
 msgstr "Revisa la renovación más reciente de tu contrato de arrendamiento."
 
-#: src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx:79
+#: src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx:80
 msgid "City data indicates that there aren’t any residential units at this address."
 msgstr "Los datos municipales indican que no hay ninguna vivienda en esta dirección."
 
@@ -300,15 +308,15 @@ msgstr "Cerrar"
 msgid "Close modal"
 msgstr "Cerrar modal"
 
-#: src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx:117
+#: src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx:118
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: src/Components/Pages/Results/Results.tsx:624
+#: src/Components/Pages/Results/Results.tsx:631
 msgid "Copied"
 msgstr "Copiado"
 
-#: src/Components/Pages/Results/Results.tsx:616
+#: src/Components/Pages/Results/Results.tsx:623
 msgid "Copy goodcausenyc.org"
 msgstr "Copiar goodcausenyc.org"
 
@@ -320,7 +328,7 @@ msgstr "Notificación de demanda"
 msgid "Demolition"
 msgstr "Demolición"
 
-#: src/Components/Footer/Footer.tsx:20
+#: src/Components/Footer/Footer.tsx:23
 msgid "Disclaimer"
 msgstr "Descargo de responsabilidad"
 
@@ -383,7 +391,7 @@ msgstr "Preguntas frecuentes para ayudarle a encontrar la respuesta"
 msgid "February 19, 2025"
 msgstr "19 de febrero de 2025"
 
-#: src/Components/Footer/Footer.tsx:52
+#: src/Components/Footer/Footer.tsx:55
 msgid "Feedback Form"
 msgstr "Formulario de comentarios"
 
@@ -391,7 +399,7 @@ msgstr "Formulario de comentarios"
 msgid "Fill out the request form"
 msgstr "Llene el formulario de solicitud."
 
-#: src/Components/Pages/Results/Results.tsx:483
+#: src/Components/Pages/Results/Results.tsx:490
 msgid "Find other buildings your landlord owns"
 msgstr "Busca otros edificios que sean propiedad de tu arrendador."
 
@@ -406,7 +414,7 @@ msgid "Find out if you’re covered by Good Cause"
 msgstr "Averigüe si está cubierto por una justa causa"
 
 #: src/Components/Pages/RentStabilization/RentStabilization.tsx:42
-#: src/Components/Pages/Results/Results.tsx:460
+#: src/Components/Pages/Results/Results.tsx:467
 #: src/Components/Pages/TenantRights/TenantRights.tsx:44
 #: src/hooks/useCriteriaResults.tsx:321
 msgid "Find out if your apartment is rent stabilized"
@@ -415,6 +423,10 @@ msgstr "Averigüe si su departamento tiene renta estabilizada."
 #: src/Components/Pages/PortfolioSize/PortfolioSize.tsx:70
 msgid "Find out if your landlord owns other buildings"
 msgstr "Averigüe si su arrendador es propietario de otros edificios."
+
+#: src/hooks/useCriteriaResults.tsx:169
+msgid "Find your landlord’s other buildings"
+msgstr ""
 
 #. placeholder {0}: bedrooms === "STUDIO" ? ( <Trans>studio</Trans> ) : ( <Trans>{bedrooms} bedroom</Trans> )
 #. placeholder {1}: formatMoney(RENT_CUTOFFS[bedrooms], 0)
@@ -428,7 +440,7 @@ msgstr "Para cualquiera de las direcciones que se enumeran a continuación, solo
 
 #: src/Components/KYRContent/KYRContent.tsx:616
 msgid "For rent-stabilized leases being renewed between October 1, 2024 and September 30, 2025 the legal rent may be increased at the following levels: for a one-year renewal there is a 2.75% increase, or for a two-year renewal there is a 5.25% increase."
-msgstr "Para los contratos de alquiler estabilizado que se renueven entre el 1 de octubre de 2024 y el 30 de septiembre de 2025, el alquiler legal podrá incrementarse en los siguientes porcentajes: para una renovación de un año, el incremento será del 2.75 %, y para una renovación de dos años, el incremento será del 5.25 %."
+msgstr "Para los contratos de alquiler estabilizado que se renueven entre el 1 de octubre de 2024 y el 30 de septiembre de 2025, el alquiler legal podrá incrementarse en los siguientes porcentajes: para una renovación de un año, el incremento será del 2.75%, y para una renovación de dos años, el incremento será del 5.25%."
 
 #: src/Components/Modal/Modal.tsx:109
 msgid "Full image of this example lease can be viewed on <0>hcr.ny.gov</0>"
@@ -443,7 +455,7 @@ msgid "Get started"
 msgstr "Comenzar"
 
 #. placeholder {0}: bldgData.unitsres
-#: src/Components/Pages/Results/Results.tsx:475
+#: src/Components/Pages/Results/Results.tsx:482
 msgid "Good Cause Eviction law only covers tenants whose landlord owns more than 10 apartments. Your building has only {0} apartments, but your landlord may own other buildings."
 msgstr "La ley de desalojo por justa causa solo cubre a los inquilinos cuyo propietario posea más de 10 departamentos. Su edificio solo tiene {0} departamentos, pero es posible que su propietario posea otros edificios."
 
@@ -463,10 +475,10 @@ msgstr "Las protecciones contra el desalojo por justa causa entraron en vigor el
 msgid "Good Cause law can be complex to understand and to use to protect yourself. This site exists to make it easier for you and your neighbors to understand your tenant protections and to assert your rights."
 msgstr "La ley de justa causa puede ser difícil de entender y de utilizar para protegerse. Este sitio web existe para facilitarle a usted y a sus vecinos la comprensión de las protecciones de los inquilinos y la defensa de sus derechos."
 
-#: src/Components/Footer/Footer.tsx:60
-#: src/Components/TopBar/TopBar.tsx:24
+#: src/Components/Footer/Footer.tsx:63
+#: src/Components/TopBar/TopBar.tsx:26
 msgid "Good Cause NYC"
-msgstr "Justa causa NYC"
+msgstr "Justa Causa NYC"
 
 #: src/Components/Pages/PortfolioSize/PortfolioSize.tsx:398
 msgid "Google your landlord’s name and find mentions of other buildings they may own in the press."
@@ -477,7 +489,7 @@ msgid "Has your landlord raised your rent? Is your landlord refusing to do basic
 msgstr "¿Tu arrendador te ha subido el alquiler? ¿Tu arrendador se niega a hacer reparaciones básicas? ¿Te preocupa que te desalojen o no te renueven el contrato?"
 
 #: src/Components/Pages/PortfolioSize/PortfolioSize.tsx:276
-#: src/Components/Pages/Results/Results.tsx:489
+#: src/Components/Pages/Results/Results.tsx:496
 msgid "Have you learned something new?"
 msgstr "¿Has aprendido algo nuevo?"
 
@@ -522,7 +534,7 @@ msgstr "Cómo encontrar otros departamentos que sean propiedad de tu arrendador"
 msgid "How to find out if your apartment is rent stabilized"
 msgstr "Cómo saber si tu departamento tiene renta estabilizada"
 
-#: src/Components/Pages/Results/Results.tsx:376
+#: src/Components/Pages/Results/Results.tsx:378
 msgid "How we determined your coverage"
 msgstr "Cómo determinamos su cobertura"
 
@@ -721,7 +733,7 @@ msgstr "Tamaño de la cartera del propietario"
 msgid "Landlords can increase the rent more than the reasonable rent increase but they must explain why and must point to increases in their costs or substantial repairs they did to the apartment or building."
 msgstr "Los propietarios pueden aumentar el alquiler más allá del incremento razonable, pero deben explicar por qué y señalar los aumentos en sus costos o las reparaciones sustanciales que realizaron en el departamento o el edificio."
 
-#: src/Components/Footer/Footer.tsx:13
+#: src/Components/Footer/Footer.tsx:16
 msgid "Language"
 msgstr "Idioma"
 
@@ -863,7 +875,7 @@ msgstr "Cargando tus resultados..."
 msgid "manufactured housing"
 msgstr "vivienda prefabricada"
 
-#: src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx:95
+#: src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx:96
 msgid "Map showing location of the entered address."
 msgstr "Mapa que muestra la ubicación de la dirección ingresada."
 
@@ -911,6 +923,10 @@ msgstr "Más recursos sobre sus derechos como inquilino en la ciudad de Nueva Yo
 #: src/helpers.ts:165
 msgid "Mortgage"
 msgstr "Hipoteca"
+
+#: src/Components/Pages/Results/Results.tsx:405
+msgid "Need to update your information?"
+msgstr ""
 
 #: src/Components/Pages/Form/Survey.tsx:232
 #: src/Components/Pages/Form/Survey.tsx:307
@@ -988,6 +1004,10 @@ msgstr "Proyecto de Justicia en Vivienda Pública de NYLAG"
 msgid "Once you find the name of your building’s owner, remember it because you’ll need it in Step 2."
 msgstr "Una vez que encuentres el nombre del propietario de tu edificio, recuérdalo porque lo necesitarás en el paso 2."
 
+#: src/hooks/useCriteriaResults.tsx:167
+msgid "other buildings."
+msgstr "otros edificios."
+
 #: src/Components/Pages/Form/Survey.tsx:254
 #~ msgid "Other subsidized housing"
 #~ msgstr "Other subsidized housing"
@@ -1021,7 +1041,7 @@ msgstr "Número de teléfono enviado"
 msgid "Please complete the unanswered questions before continuing."
 msgstr "Por favor, responda las preguntas sin contestar antes de continuar."
 
-#: src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx:66
+#: src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx:67
 msgid "Please confirm your address"
 msgstr "Por favor, confirme su dirección."
 
@@ -1062,7 +1082,7 @@ msgstr "Cobertura impresa"
 msgid "Privacy policy"
 msgstr "Política de privacidad"
 
-#: src/Components/Footer/Footer.tsx:36
+#: src/Components/Footer/Footer.tsx:39
 msgid "Privacy Policy"
 msgstr "Política de privacidad"
 
@@ -1157,7 +1177,7 @@ msgstr "Recuerda que tu edificio tiene {0, plural, one {# apartamento} other {# 
 msgid "Rent Amount"
 msgstr "Importe del alquiler"
 
-#: src/Components/TopBar/TopBar.tsx:53
+#: src/Components/TopBar/TopBar.tsx:55
 msgid "Rent increase calculator"
 msgstr "Calculadora de aumento de renta"
 
@@ -1189,7 +1209,7 @@ msgstr "Guía para inquilinos residenciales"
 msgid "Result"
 msgstr "Resultado"
 
-#: src/Components/Pages/Results/Results.tsx:379
+#: src/Components/Pages/Results/Results.tsx:381
 msgid "Results are based on publicly available data about your building and the answers you provided. This does not constitute legal advice."
 msgstr "Los resultados se basan en datos públicos sobre su edificio y en las respuestas que usted ha proporcionado. Esto no constituye asesoramiento legal."
 
@@ -1201,7 +1221,7 @@ msgstr "Imagen de ejemplo de contrato de alquiler estabilizado en blanco"
 msgid "Save your result to your phone"
 msgstr "Guarda el resultado en tu teléfono."
 
-#: src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx:85
+#: src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx:86
 msgid "Search new address"
 msgstr "Buscar nueva dirección"
 
@@ -1311,7 +1331,7 @@ msgstr "Los inquilinos tienen derecho a vivir en un departamento seguro, higién
 msgid "Terms of use"
 msgstr "Condiciones de uso"
 
-#: src/Components/Footer/Footer.tsx:44
+#: src/Components/Footer/Footer.tsx:47
 msgid "Terms of Use"
 msgstr "Condiciones de uso"
 
@@ -1342,9 +1362,9 @@ msgstr "El edificio no debe formar parte de NYCHA, PACT/RAD u otras viviendas su
 #. placeholder {1}: CPI + 5
 #: src/Components/Pages/RentCalculator/RentCalculator.tsx:122
 msgid "The Good Cause law establishes a Reasonable Rent Increase, which is set every year at the rate of inflation plus 5%, with a maximum of 10% total. As of ${0}, the rate of inflation for New York City is ${CPI}%, meaning that the current local Reasonable Rent Increase is ${1}%."
-msgstr "La ley Good Cause establece un aumento razonable del alquiler, que se fija cada año según la tasa de inflación más un 5 %, con un máximo del 10 % en total. Según ${0}, la tasa de inflación de la ciudad de Nueva York es del ${CPI}%, lo que significa que el aumento razonable del alquiler local actual es del ${1}%."
+msgstr "La ley Good Cause establece un aumento razonable del alquiler, que se fija cada año según la tasa de inflación más un 5%, con un máximo del 10% en total. Según ${0}, la tasa de inflación de la ciudad de Nueva York es del ${CPI}%, lo que significa que el aumento razonable del alquiler local actual es del ${1}%."
 
-#: src/Components/Footer/Footer.tsx:22
+#: src/Components/Footer/Footer.tsx:25
 msgid "The information on this website does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing."
 msgstr "La información contenida en este sitio web no constituye asesoramiento jurídico y no debe utilizarse como sustituto del asesoramiento de un abogado calificado para asesorar sobre cuestiones legales relacionadas con la vivienda."
 
@@ -1378,7 +1398,7 @@ msgstr "El propietario del edificio puede ser diferente de la persona que figura
 msgid "The state housing agency must publish each year’s Reasonable Rent Increase by August. This year the maximum amount your landlord can increase your rent by is ${increase_pct}%."
 msgstr "La agencia estatal de vivienda debe publicar cada año el aumento razonable del alquiler antes de agosto. Este año, el monto máximo en que el propietario puede aumentar el alquiler es del ${increase_pct}%."
 
-#: src/Components/Pages/Results/Results.tsx:434
+#: src/Components/Pages/Results/Results.tsx:441
 msgid "There {steps, plural, one {is # thing} other {are # things}} you need to verify to confirm your coverage"
 msgstr "Hay {steps, plural, one {es # cosa} other {son # cosas}} que debes verificar para confirmar tu cobertura."
 
@@ -1512,11 +1532,11 @@ msgstr "No podemos enlazar directamente con documentos específicos de propiedad
 msgid "We check for NYCHA, Mitchell-Lama, HDFC, LIHTC, Project Section 8, and various HPD and HUD programs. If you know the public data is incorrect, use these tips to guide your answer:"
 msgstr "Verificamos los programas NYCHA, Mitchell-Lama, HDFC, LIHTC, Proyecto Sección 8 y varios programas HPD y HUD. Si sabe que los datos públicos son incorrectos, utilice estos consejos para orientar su respuesta:"
 
-#: src/Components/Pages/Results/Results.tsx:443
+#: src/Components/Pages/Results/Results.tsx:450
 msgid "We need to confirm if your apartment is rent stabilized"
 msgstr "Necesitamos confirmar si su departamento tiene renta estabilizada."
 
-#: src/Components/Pages/Results/Results.tsx:468
+#: src/Components/Pages/Results/Results.tsx:475
 msgid "We need to confirm if your landlord owns more than 10 apartments"
 msgstr "Necesitamos confirmar si su arrendador es propietario de más de 10 departamentos."
 
@@ -1537,7 +1557,7 @@ msgstr "Nunca te llamaremos ni compartiremos tu número de teléfono. Es posible
 msgid "We’ll text you once a year to learn about your housing conditions. We’ll use your answers to better advocate for your rights."
 msgstr "Te enviaremos un mensaje de texto una vez al año para conocer tus condiciones de vivienda. Utilizaremos tus respuestas para defender mejor tus derechos."
 
-#: src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx:68
+#: src/Components/Pages/ConfirmAddress/ConfirmAddress.tsx:69
 msgid "We’ll use publicly available information about your building to help learn if you’re covered."
 msgstr "Utilizaremos la información pública disponible sobre su edificio para saber si está cubierto."
 
@@ -1686,7 +1706,7 @@ msgstr "Usted informó que su renta es de {0}."
 msgid "You told us that that you live subsidized housing. If your building is subsidized then you are not covered by Good Cause Eviction law because you should already have important tenant protections associated with your building’s subsidy."
 msgstr "Nos dijiste que vives en una vivienda subsidiada. Si tu edificio está subsidiado, entonces no estás cubierto por la ley de desalojo por justa causa, ya que deberías contar con importantes protecciones para inquilinos asociadas con el subsidio de tu edificio."
 
-#: src/Components/Pages/Results/Results.tsx:450
+#: src/Components/Pages/Results/Results.tsx:457
 msgid "You told us that you are unsure if you are rent stabilized. If your apartment is rent stabilized, you are not covered by Good Cause Eviction law, but rent stabilized protections are even stronger than the Good Cause Eviction law."
 msgstr "Nos ha dicho que no está seguro de si su renta está estabilizada. Si su departamento tiene renta estabilizada, no está cubierto por la ley de desalojo por justa causa, pero las protecciones de la renta estabilizada son aún más sólidas que la ley de desalojo por justa causa."
 
@@ -1736,10 +1756,13 @@ msgstr "Su edificio tiene ${0} apartamentos y usted ha informado de que su arren
 msgid "Your building has no new recorded certificate of occupancy since 2009."
 msgstr "Su edificio no tiene ningún certificado de ocupación nuevo registrado desde 2009."
 
-#. placeholder {1}: relatedProperties ? ( <Trans> publicly available data sources indicate that your landlord may be associated with {formatNumber(relatedProperties)} </Trans> ) : ( <Trans>your landlord may own</Trans> )
+#: src/hooks/useCriteriaResults.tsx:158
+msgid "Your building has only {pluralApartments}, but"
+msgstr "Tu edificio solo tiene {pluralApartments}, pero"
+
 #: src/hooks/useCriteriaResults.tsx:157
-msgid "Your building has only {pluralApartments}, but{1} other buildings. <0>Find your landlord’s other buildings</0>"
-msgstr "Tu edificio solo tiene {pluralApartments}, pero{1} otros edificios. <0>Busca los otros edificios de tu propietario</0>."
+#~ msgid "Your building has only {pluralApartments}, but{1} other buildings. <0>Find your landlord’s other buildings</0>"
+#~ msgstr "Tu edificio solo tiene {pluralApartments}, pero{1} otros edificios. <0>Busca los otros edificios de tu propietario</0>."
 
 #. placeholder {0}: activeJ51 ? "421a" : "J51"
 #: src/hooks/useCriteriaResults.tsx:357
@@ -1776,7 +1799,7 @@ msgstr "tu arrendador puede ser propietario de"
 
 #: src/Components/KYRContent/KYRContent.tsx:492
 msgid "Your landlord must give you written notice to raise your rent more than 5% (30 days notice if you’ve lived there less than 1 year, 60 days if you’ve lived there 1-2 years, and 90 days notice if you’ve lived there longer than 2 years). If your landlord tries to raise rent without proper notice, inform them they are violating <0>Real Property Law L Section 226-C</0>. Do not pay any rent increase until they give written notice."
-msgstr "Tu arrendador debe notificarte por escrito cualquier aumento del alquiler superior al 5 % (con 30 días de antelación si llevas menos de un año viviendo allí, 60 días si llevas entre uno y dos años, y 90 días si llevas más de dos años). Si su arrendador intenta aumentar el alquiler sin la notificación adecuada, infórmele de que está infringiendo <0>la Ley de Bienes Inmuebles, sección 226-C</0>. No pague ningún aumento de alquiler hasta que le envíe una notificación por escrito."
+msgstr "Tu arrendador debe notificarte por escrito cualquier aumento del alquiler superior al 5% (con 30 días de antelación si llevas menos de un año viviendo allí, 60 días si llevas entre uno y dos años, y 90 días si llevas más de dos años). Si su arrendador intenta aumentar el alquiler sin la notificación adecuada, infórmele de que está infringiendo <0>la Ley de Bienes Inmuebles, sección 226-C</0>. No pague ningún aumento de alquiler hasta que le envíe una notificación por escrito."
 
 #: src/Components/KYRContent/KYRContent.tsx:353
 msgid "Your landlord will need to provide a good reason for ending a tenancy. Even if your lease expires, your landlord cannot evict you, as long as you abide by the terms of your expired lease."


### PR DESCRIPTION
Now with the locale routes if you link to a page without the locale it will check browser preferences again, so we need to include the current active locale in all links. Otherwise you could have browser preferences to EN, manually switch to ES, then click a link like `/survey` and it would switch you back to EN. 

While going through and doing more testing I caught a few more strings that were missing or not working properly so I've added more to translate.