### PR TITLE
refactor rentstab criteria table copy to simplify lingui

### DIFF
--- a/src/hooks/useCriteriaResults.tsx
+++ b/src/hooks/useCriteriaResults.tsx
@@ -344,41 +344,44 @@ function eligibilityRentStabilized(
     userValue = (
       <Trans>You reported that your apartment is rent stabilized.</Trans>
     );
-  } else {
-    determination = rentStabilized === "NO" ? "ELIGIBLE" : "UNKNOWN";
-    userValue =
-      allUnitsRS || active421a || activeJ51 ? (
-        <>
-          You reported that{" "}
-          {rentStabilized === "NO" ? (
-            <>your apartment is not</>
-          ) : (
-            <>you are not sure if your apartment is</>
-          )}{" "}
-          rent stabilized, and we are using your answer as part of our coverage
-          assessment. Note: publicly available data sources indicate that
-          {allUnitsRS ? (
-            <>
-              all apartments in your building are registered as rent stabilized.
-            </>
-          ) : (
-            <>
-              your building receives the {activeJ51 ? "421a" : "J51"} tax
-              incentive, which means your apartment should be rent stabilized.
-            </>
-          )}{" "}
-          {allUnitsRS ? wowLink : subsidyLink}{" "}
-          If those sources are correct, then you may already have stronger
-          tenant protections than Good Cause Eviction provides. {guideLink}
-        </>
-      ) : rentStabilized === "NO" ? (
-        <>You reported that your apartment is not rent stabilized.</>
-      ) : (
-        <>
-          You reported that you are not sure if your apartment is rent
-          stabilized. {guideLink}
-        </>
+  } else if (rentStabilized === "NO") {
+    determination = "ELIGIBLE";
+    if (allUnitsRS) {
+      userValue = (
+        <Trans>
+          You reported that your apartment is not rent stabilized, and we are
+          using your answer as part of our coverage assessment. Note: publicly
+          available data sources indicate that all apartments in your building
+          are registered as rent stabilized. {wowLink} If those sources are
+          correct, then you may already have stronger tenant protections than
+          Good Cause Eviction provides. {guideLink}
+        </Trans>
       );
+    } else if (active421a || activeJ51) {
+      userValue = (
+        <Trans>
+          You reported that your apartment is not rent stabilized, and we are
+          using your answer as part of our coverage assessment. Note: publicly
+          available data sources indicate that your building receives the{" "}
+          {activeJ51 ? "421a" : "J51"} tax incentive, which means your apartment
+          should be rent stabilized. {subsidyLink} If those sources are correct,
+          then you may already have stronger tenant protections than Good Cause
+          Eviction provides. {guideLink}
+        </Trans>
+      );
+    } else {
+      userValue = (
+        <Trans>You reported that your apartment is not rent stabilized.</Trans>
+      );
+    }
+  } else {
+    determination = "UNKNOWN";
+    userValue = (
+      <Trans>
+        You reported that you are not sure if your apartment is rent stabilized.{" "}
+        {guideLink}
+      </Trans>
+    );
   }
 
   return {

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -142,11 +142,11 @@ msgstr "5. Does your landlord live in the building?"
 msgid "6. Does your landlord own more than 10 apartments across multiple buildings?"
 msgstr "6. Does your landlord own more than 10 apartments across multiple buildings?"
 
-#: src/hooks/useCriteriaResults.tsx:416
+#: src/hooks/useCriteriaResults.tsx:419
 msgid "a co-op"
 msgstr "a co-op"
 
-#: src/hooks/useCriteriaResults.tsx:413
+#: src/hooks/useCriteriaResults.tsx:416
 msgid "a condo"
 msgstr "a condo"
 
@@ -279,19 +279,19 @@ msgstr "Check your most recent lease renewal"
 msgid "City data indicates that there aren’t any residential units at this address."
 msgstr "City data indicates that there aren’t any residential units at this address."
 
-#: src/hooks/useCriteriaResults.tsx:428
+#: src/hooks/useCriteriaResults.tsx:431
 msgid "classified as a health facility"
 msgstr "classified as a health facility"
 
-#: src/hooks/useCriteriaResults.tsx:422
+#: src/hooks/useCriteriaResults.tsx:425
 msgid "classified as a hotel"
 msgstr "classified as a hotel"
 
-#: src/hooks/useCriteriaResults.tsx:425
+#: src/hooks/useCriteriaResults.tsx:428
 msgid "classified as a religious facility"
 msgstr "classified as a religious facility"
 
-#: src/hooks/useCriteriaResults.tsx:419
+#: src/hooks/useCriteriaResults.tsx:422
 msgid "classified as an educational building"
 msgstr "classified as an educational building"
 
@@ -542,15 +542,15 @@ msgstr "I'm not sure"
 msgid "If the building has 10 or fewer apartments, the landlord must not also live in it."
 msgstr "If the building has 10 or fewer apartments, the landlord must not also live in it."
 
-#: src/hooks/useCriteriaResults.tsx:593
+#: src/hooks/useCriteriaResults.tsx:596
 msgid "If those sources are correct, then you may already have stronger tenant protections than other subsidized housing programs."
 msgstr "If those sources are correct, then you may already have stronger tenant protections than other subsidized housing programs."
 
-#: src/hooks/useCriteriaResults.tsx:616
+#: src/hooks/useCriteriaResults.tsx:619
 msgid "If those sources are correct, you may have existing tenant protections through NYCHA or PACT/RAD."
 msgstr "If those sources are correct, you may have existing tenant protections through NYCHA or PACT/RAD."
 
-#: src/hooks/useCriteriaResults.tsx:673
+#: src/hooks/useCriteriaResults.tsx:676
 msgid "If those sources are correct, you may have existing tenant protections through your building’s subsidy program."
 msgstr "If those sources are correct, you may have existing tenant protections through your building’s subsidy program."
 
@@ -866,7 +866,7 @@ msgstr "Loading document links..."
 msgid "Loading your results..."
 msgstr "Loading your results..."
 
-#: src/hooks/useCriteriaResults.tsx:407
+#: src/hooks/useCriteriaResults.tsx:410
 msgid "manufactured housing"
 msgstr "manufactured housing"
 
@@ -907,7 +907,7 @@ msgstr "Met Council on Housing’s Hotline"
 msgid "Met Council on Housing’s Rent Stabilization overview"
 msgstr "Met Council on Housing’s Rent Stabilization overview"
 
-#: src/hooks/useCriteriaResults.tsx:410
+#: src/hooks/useCriteriaResults.tsx:413
 msgid "missing class information"
 msgstr "missing class information"
 
@@ -974,12 +974,12 @@ msgstr "NY Courts Warranty of Habitability fact sheet"
 msgid "NY Homes and Community Renewal eviction information"
 msgstr "NY Homes and Community Renewal eviction information"
 
-#: src/hooks/useCriteriaResults.tsx:626
+#: src/hooks/useCriteriaResults.tsx:629
 msgid "NYCHA and PACT/RAD apartments are not covered by Good Cause because they already have stronger tenant protections than Good Cause provides."
 msgstr "NYCHA and PACT/RAD apartments are not covered by Good Cause because they already have stronger tenant protections than Good Cause provides."
 
-#: src/hooks/useCriteriaResults.tsx:539
-#: src/hooks/useCriteriaResults.tsx:565
+#: src/hooks/useCriteriaResults.tsx:542
+#: src/hooks/useCriteriaResults.tsx:568
 msgid "NYCHA and PACT/RAD apartments are not covered by Good Cause because they already have stronger tenant protections than Good Cause."
 msgstr "NYCHA and PACT/RAD apartments are not covered by Good Cause because they already have stronger tenant protections than Good Cause."
 
@@ -1101,11 +1101,11 @@ msgstr "Protections that all NYC tenants have"
 msgid "Protections under Good Cause"
 msgstr "Protections under Good Cause"
 
-#: src/hooks/useCriteriaResults.tsx:442
+#: src/hooks/useCriteriaResults.tsx:445
 msgid "Public data sources indicate that your building is {bldgTypeName}, and so is not covered by Good Cause Eviction."
 msgstr "Public data sources indicate that your building is {bldgTypeName}, and so is not covered by Good Cause Eviction."
 
-#: src/hooks/useCriteriaResults.tsx:437
+#: src/hooks/useCriteriaResults.tsx:440
 msgid "Public data sources indicate that your building is not a condo, co-op, or other exempt category."
 msgstr "Public data sources indicate that your building is not a condo, co-op, or other exempt category."
 
@@ -1275,8 +1275,8 @@ msgstr "Studio"
 msgid "Submit"
 msgstr "Submit"
 
-#: src/hooks/useCriteriaResults.tsx:548
-#: src/hooks/useCriteriaResults.tsx:646
+#: src/hooks/useCriteriaResults.tsx:551
+#: src/hooks/useCriteriaResults.tsx:649
 msgid "Subsidized buildings are not covered by Good Cause Eviction because they already have similar, and sometimes stronger, existing tenant protections."
 msgstr "Subsidized buildings are not covered by Good Cause Eviction because they already have similar, and sometimes stronger, existing tenant protections."
 
@@ -1338,18 +1338,18 @@ msgstr "The apartment must not be rent stabilized."
 msgid "The best way to confirm the owner of your building is to review your building’s official real estate transaction documents and look for the owner’s signature. We have provided links to these documents, below."
 msgstr "The best way to confirm the owner of your building is to review your building’s official real estate transaction documents and look for the owner’s signature. We have provided links to these documents, below."
 
-#: src/hooks/useCriteriaResults.tsx:475
+#: src/hooks/useCriteriaResults.tsx:478
 msgid "The building must have received its certificate of occupancy before 2009."
 msgstr "The building must have received its certificate of occupancy before 2009."
 
-#: src/hooks/useCriteriaResults.tsx:398
+#: src/hooks/useCriteriaResults.tsx:401
 msgid "The building must not be a condo, co-op, or other exempt building types."
 msgstr "The building must not be a condo, co-op, or other exempt building types."
 
-#: src/hooks/useCriteriaResults.tsx:526
-#: src/hooks/useCriteriaResults.tsx:578
-#: src/hooks/useCriteriaResults.tsx:601
-#: src/hooks/useCriteriaResults.tsx:656
+#: src/hooks/useCriteriaResults.tsx:529
+#: src/hooks/useCriteriaResults.tsx:581
+#: src/hooks/useCriteriaResults.tsx:604
+#: src/hooks/useCriteriaResults.tsx:659
 msgid "The building must not be part of NYCHA, PACT/RAD, or other subsidized housing."
 msgstr "The building must not be part of NYCHA, PACT/RAD, or other subsidized housing."
 
@@ -1497,9 +1497,9 @@ msgstr "View all documents in ACRIS"
 #: src/hooks/useCriteriaResults.tsx:235
 #: src/hooks/useCriteriaResults.tsx:317
 #: src/hooks/useCriteriaResults.tsx:322
-#: src/hooks/useCriteriaResults.tsx:448
-#: src/hooks/useCriteriaResults.tsx:497
-#: src/hooks/useCriteriaResults.tsx:519
+#: src/hooks/useCriteriaResults.tsx:451
+#: src/hooks/useCriteriaResults.tsx:500
+#: src/hooks/useCriteriaResults.tsx:522
 msgid "View source"
 msgstr "View source"
 
@@ -1627,19 +1627,28 @@ msgstr "You only need to find the name or signature of your building’s owner o
 #~ msgid "You reported that {0} rent stabilized, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that{2} {3}If those sources are correct, then you may already have stronger tenant protections than Good Cause Eviction provides. {guideLink}"
 #~ msgstr "You reported that {0} rent stabilized, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that{2} {3}If those sources are correct, then you may already have stronger tenant protections than Good Cause Eviction provides. {guideLink}"
 
-#: src/hooks/useCriteriaResults.tsx:377
-#~ msgid "You reported that you are not sure if your apartment is rent stabilized. {guideLink}"
-#~ msgstr "You reported that you are not sure if your apartment is rent stabilized. {guideLink}"
+#: src/hooks/useCriteriaResults.tsx:380
+msgid "You reported that you are not sure if your apartment is rent stabilized. {guideLink}"
+msgstr "You reported that you are not sure if your apartment is rent stabilized. {guideLink}"
 
-#: src/hooks/useCriteriaResults.tsx:375
-#~ msgid "You reported that your apartment is not rent stabilized."
-#~ msgstr "You reported that your apartment is not rent stabilized."
+#: src/hooks/useCriteriaResults.tsx:351
+msgid "You reported that your apartment is not rent stabilized, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that all apartments in your building are registered as rent stabilized. {wowLink} If those sources are correct, then you may already have stronger tenant protections than Good Cause Eviction provides. {guideLink}"
+msgstr "You reported that your apartment is not rent stabilized, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that all apartments in your building are registered as rent stabilized. {wowLink} If those sources are correct, then you may already have stronger tenant protections than Good Cause Eviction provides. {guideLink}"
+
+#. placeholder {0}: activeJ51 ? "421a" : "J51"
+#: src/hooks/useCriteriaResults.tsx:362
+msgid "You reported that your apartment is not rent stabilized, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building receives the {0} tax incentive, which means your apartment should be rent stabilized. {subsidyLink} If those sources are correct, then you may already have stronger tenant protections than Good Cause Eviction provides. {guideLink}"
+msgstr "You reported that your apartment is not rent stabilized, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building receives the {0} tax incentive, which means your apartment should be rent stabilized. {subsidyLink} If those sources are correct, then you may already have stronger tenant protections than Good Cause Eviction provides. {guideLink}"
+
+#: src/hooks/useCriteriaResults.tsx:374
+msgid "You reported that your apartment is not rent stabilized."
+msgstr "You reported that your apartment is not rent stabilized."
 
 #: src/hooks/useCriteriaResults.tsx:345
 msgid "You reported that your apartment is rent stabilized."
 msgstr "You reported that your apartment is rent stabilized."
 
-#: src/hooks/useCriteriaResults.tsx:609
+#: src/hooks/useCriteriaResults.tsx:612
 msgid "You reported that your building is not part of any subsidized housing programs, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building is part of NYCHA or PACT/RAD."
 msgstr "You reported that your building is not part of any subsidized housing programs, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building is part of NYCHA or PACT/RAD."
 
@@ -1647,7 +1656,7 @@ msgstr "You reported that your building is not part of any subsidized housing pr
 #~ msgid "You reported that your building is not part of any subsidized housing programs, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building is part of NYCHA or PACT/RAD. {sourceLink} If those sources are correct, you may have existing tenant protections through NYCHA or PACT/RAD."
 #~ msgstr "You reported that your building is not part of any subsidized housing programs, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building is part of NYCHA or PACT/RAD. {sourceLink} If those sources are correct, you may have existing tenant protections through NYCHA or PACT/RAD."
 
-#: src/hooks/useCriteriaResults.tsx:556
+#: src/hooks/useCriteriaResults.tsx:559
 msgid "You reported that your building is not part of NYCHA, PACT/RAD, or other subsidized housing programs."
 msgstr "You reported that your building is not part of NYCHA, PACT/RAD, or other subsidized housing programs."
 
@@ -1655,7 +1664,7 @@ msgstr "You reported that your building is not part of NYCHA, PACT/RAD, or other
 #~ msgid "You reported that your building is not part of NYCHA, PACT/RAD, or other subsidized housing, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building {0} , which is considered subsidized housing. {sourceLink} If those sources are correct, you may have existing tenant protections through your building’s subsidy program."
 #~ msgstr "You reported that your building is not part of NYCHA, PACT/RAD, or other subsidized housing, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building {0} , which is considered subsidized housing. {sourceLink} If those sources are correct, you may have existing tenant protections through your building’s subsidy program."
 
-#: src/hooks/useCriteriaResults.tsx:664
+#: src/hooks/useCriteriaResults.tsx:667
 msgid "You reported that your building is not part of NYCHA, PACT/RAD, or other subsidized housing, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building <0/> , which is considered subsidized housing."
 msgstr "You reported that your building is not part of NYCHA, PACT/RAD, or other subsidized housing, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building <0/> , which is considered subsidized housing."
 
@@ -1667,16 +1676,16 @@ msgstr "You reported that your building is not part of NYCHA, PACT/RAD, or other
 #~ msgid "You reported that your building is part of NYCHA or PACT/RAD, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building {0}, which is considered subsidized housing. {sourceLink} If those sources are correct, then your protections may be different than the protections of NYCHA or PACT/RAD."
 #~ msgstr "You reported that your building is part of NYCHA or PACT/RAD, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building {0}, which is considered subsidized housing. {sourceLink} If those sources are correct, then your protections may be different than the protections of NYCHA or PACT/RAD."
 
-#: src/hooks/useCriteriaResults.tsx:634
+#: src/hooks/useCriteriaResults.tsx:637
 msgid "You reported that your building is part of NYCHA or PACT/RAD, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building <0/>, which is considered subsidized housing. {sourceLink} If those sources are correct, then your protections may be different than the protections of NYCHA or PACT/RAD."
 msgstr "You reported that your building is part of NYCHA or PACT/RAD, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building <0/>, which is considered subsidized housing. {sourceLink} If those sources are correct, then your protections may be different than the protections of NYCHA or PACT/RAD."
 
-#: src/hooks/useCriteriaResults.tsx:533
-#: src/hooks/useCriteriaResults.tsx:572
+#: src/hooks/useCriteriaResults.tsx:536
+#: src/hooks/useCriteriaResults.tsx:575
 msgid "You reported that your building is part of NYCHA or PACT/RAD."
 msgstr "You reported that your building is part of NYCHA or PACT/RAD."
 
-#: src/hooks/useCriteriaResults.tsx:586
+#: src/hooks/useCriteriaResults.tsx:589
 msgid "You reported that your building is subsidized, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building is part of NYCHA or PACT/RAD."
 msgstr "You reported that your building is subsidized, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building is part of NYCHA or PACT/RAD."
 
@@ -1684,8 +1693,8 @@ msgstr "You reported that your building is subsidized, and we are using your ans
 #~ msgid "You reported that your building is subsidized, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building is part of NYCHA or PACT/RAD. {sourceLink} If those sources are correct, then you may already have stronger tenant protections than other subsidized housing programs."
 #~ msgstr "You reported that your building is subsidized, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building is part of NYCHA or PACT/RAD. {sourceLink} If those sources are correct, then you may already have stronger tenant protections than other subsidized housing programs."
 
-#: src/hooks/useCriteriaResults.tsx:545
-#: src/hooks/useCriteriaResults.tsx:653
+#: src/hooks/useCriteriaResults.tsx:548
+#: src/hooks/useCriteriaResults.tsx:656
 msgid "You reported that your building is subsidized."
 msgstr "You reported that your building is subsidized."
 
@@ -1744,7 +1753,7 @@ msgstr "Your building has {unitsres, plural, one {# apartment} other {# apartmen
 msgid "Your building has ${0} apartments and you reported that your landlord does not live in the building."
 msgstr "Your building has ${0} apartments and you reported that your landlord does not live in the building."
 
-#: src/hooks/useCriteriaResults.tsx:484
+#: src/hooks/useCriteriaResults.tsx:487
 msgid "Your building has no new recorded certificate of occupancy since 2009."
 msgstr "Your building has no new recorded certificate of occupancy since 2009."
 
@@ -1760,7 +1769,7 @@ msgstr "Your building has only {pluralApartments}, but"
 #~ msgid "your building receives the {0} tax incentive, which means your apartment should be rent stabilized."
 #~ msgstr "your building receives the {0} tax incentive, which means your apartment should be rent stabilized."
 
-#: src/hooks/useCriteriaResults.tsx:488
+#: src/hooks/useCriteriaResults.tsx:491
 msgid "Your building was issued a certificate of occupancy on {latestCoDateFormatted}."
 msgstr "Your building was issued a certificate of occupancy on {latestCoDateFormatted}."
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -1638,12 +1638,12 @@ msgstr "Usted informó que no está seguro de si su departamento tiene renta est
 
 #: src/hooks/useCriteriaResults.tsx:351
 msgid "You reported that your apartment is not rent stabilized, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that all apartments in your building are registered as rent stabilized. {wowLink} If those sources are correct, then you may already have stronger tenant protections than Good Cause Eviction provides. {guideLink}"
-msgstr "aaaaa {guideLink}"
+msgstr ""
 
 #. placeholder {0}: activeJ51 ? "421a" : "J51"
 #: src/hooks/useCriteriaResults.tsx:362
 msgid "You reported that your apartment is not rent stabilized, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building receives the {0} tax incentive, which means your apartment should be rent stabilized. {subsidyLink} If those sources are correct, then you may already have stronger tenant protections than Good Cause Eviction provides. {guideLink}"
-msgstr "bbbbb {guideLink}"
+msgstr ""
 
 #: src/hooks/useCriteriaResults.tsx:374
 msgid "You reported that your apartment is not rent stabilized."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -147,11 +147,11 @@ msgstr "5. ¿Su arrendador vive en el edificio?"
 msgid "6. Does your landlord own more than 10 apartments across multiple buildings?"
 msgstr "6. ¿Su arrendador es dueño de más de 10 departamentos en varios edificios?"
 
-#: src/hooks/useCriteriaResults.tsx:416
+#: src/hooks/useCriteriaResults.tsx:419
 msgid "a co-op"
 msgstr "una cooperativa"
 
-#: src/hooks/useCriteriaResults.tsx:413
+#: src/hooks/useCriteriaResults.tsx:416
 msgid "a condo"
 msgstr "un departamento"
 
@@ -284,19 +284,19 @@ msgstr "Revisa la renovación más reciente de tu contrato de arrendamiento."
 msgid "City data indicates that there aren’t any residential units at this address."
 msgstr "Los datos municipales indican que no hay ninguna vivienda en esta dirección."
 
-#: src/hooks/useCriteriaResults.tsx:428
+#: src/hooks/useCriteriaResults.tsx:431
 msgid "classified as a health facility"
 msgstr "clasificado como centro de salud"
 
-#: src/hooks/useCriteriaResults.tsx:422
+#: src/hooks/useCriteriaResults.tsx:425
 msgid "classified as a hotel"
 msgstr "clasificado como hotel"
 
-#: src/hooks/useCriteriaResults.tsx:425
+#: src/hooks/useCriteriaResults.tsx:428
 msgid "classified as a religious facility"
 msgstr "clasificado como centro religioso"
 
-#: src/hooks/useCriteriaResults.tsx:419
+#: src/hooks/useCriteriaResults.tsx:422
 msgid "classified as an educational building"
 msgstr "clasificado como edificio educativo"
 
@@ -547,15 +547,15 @@ msgstr "No estoy seguro."
 msgid "If the building has 10 or fewer apartments, the landlord must not also live in it."
 msgstr "Si el edificio tiene 10 o menos departamentos, el propietario no debe vivir también en él."
 
-#: src/hooks/useCriteriaResults.tsx:593
+#: src/hooks/useCriteriaResults.tsx:596
 msgid "If those sources are correct, then you may already have stronger tenant protections than other subsidized housing programs."
 msgstr "Si esas fuentes son correctas, es posible que ya cuentes con protecciones para inquilinos más sólidas que otras de los programas de vivienda subsidiada."
 
-#: src/hooks/useCriteriaResults.tsx:616
+#: src/hooks/useCriteriaResults.tsx:619
 msgid "If those sources are correct, you may have existing tenant protections through NYCHA or PACT/RAD."
 msgstr "Si esas fuentes son correctas, es posible que usted cuente con protecciones para inquilinos a través de NYCHA o PACT/RAD."
 
-#: src/hooks/useCriteriaResults.tsx:673
+#: src/hooks/useCriteriaResults.tsx:676
 msgid "If those sources are correct, you may have existing tenant protections through your building’s subsidy program."
 msgstr "Si esas fuentes son correctas, es posible que usted cuente con protecciones para inquilinos a través del programa de subsidios de su edificio."
 
@@ -871,7 +871,7 @@ msgstr "Cargando enlaces a documentos..."
 msgid "Loading your results..."
 msgstr "Cargando tus resultados..."
 
-#: src/hooks/useCriteriaResults.tsx:407
+#: src/hooks/useCriteriaResults.tsx:410
 msgid "manufactured housing"
 msgstr "vivienda prefabricada"
 
@@ -912,7 +912,7 @@ msgstr "Línea directa del Consejo Metropolitano de Vivienda"
 msgid "Met Council on Housing’s Rent Stabilization overview"
 msgstr "Resumen sobre la estabilización de rentas del Consejo Metropolitano de Vivienda"
 
-#: src/hooks/useCriteriaResults.tsx:410
+#: src/hooks/useCriteriaResults.tsx:413
 msgid "missing class information"
 msgstr "información sobre clases perdidas"
 
@@ -979,12 +979,12 @@ msgstr "Hoja informativa sobre la garantía de habitabilidad de los tribunales d
 msgid "NY Homes and Community Renewal eviction information"
 msgstr "Información sobre desalojos de NY Homes and Community Renewal"
 
-#: src/hooks/useCriteriaResults.tsx:626
+#: src/hooks/useCriteriaResults.tsx:629
 msgid "NYCHA and PACT/RAD apartments are not covered by Good Cause because they already have stronger tenant protections than Good Cause provides."
 msgstr "Los departamentos de NYCHA y PACT/RAD no están cubiertos por Good Cause porque ya cuentan con protecciones para los inquilinos más sólidas que las que ofrece justa causa."
 
-#: src/hooks/useCriteriaResults.tsx:539
-#: src/hooks/useCriteriaResults.tsx:565
+#: src/hooks/useCriteriaResults.tsx:542
+#: src/hooks/useCriteriaResults.tsx:568
 msgid "NYCHA and PACT/RAD apartments are not covered by Good Cause because they already have stronger tenant protections than Good Cause."
 msgstr "Los apartamentos de NYCHA y PACT/RAD no están cubiertos por la cláusula de justa causa, ya que cuentan con protecciones para los inquilinos más sólidas que las que ofrece dicha cláusula."
 
@@ -1106,11 +1106,11 @@ msgstr "Protecciones que tienen todos los inquilinos de la ciudad de Nueva York"
 msgid "Protections under Good Cause"
 msgstr "Protecciones por justa causa"
 
-#: src/hooks/useCriteriaResults.tsx:442
+#: src/hooks/useCriteriaResults.tsx:445
 msgid "Public data sources indicate that your building is {bldgTypeName}, and so is not covered by Good Cause Eviction."
 msgstr "Las fuentes de datos públicas indican que su edificio es {bldgTypeName}, por lo que no está cubierto por el desalojo por justa causa."
 
-#: src/hooks/useCriteriaResults.tsx:437
+#: src/hooks/useCriteriaResults.tsx:440
 msgid "Public data sources indicate that your building is not a condo, co-op, or other exempt category."
 msgstr "Las fuentes de datos públicas indican que su edificio no es un condominio, una cooperativa ni pertenece a ninguna otra categoría exenta."
 
@@ -1280,8 +1280,8 @@ msgstr "Estudio"
 msgid "Submit"
 msgstr "Enviar"
 
-#: src/hooks/useCriteriaResults.tsx:548
-#: src/hooks/useCriteriaResults.tsx:646
+#: src/hooks/useCriteriaResults.tsx:551
+#: src/hooks/useCriteriaResults.tsx:649
 msgid "Subsidized buildings are not covered by Good Cause Eviction because they already have similar, and sometimes stronger, existing tenant protections."
 msgstr "Los edificios subsidiados no están cubiertos por el desalojo por justa causa, ya que cuentan con protecciones similares, y en ocasiones más sólidas, para los inquilinos."
 
@@ -1343,18 +1343,18 @@ msgstr "El departamento no debe tener renta estabilizada."
 msgid "The best way to confirm the owner of your building is to review your building’s official real estate transaction documents and look for the owner’s signature. We have provided links to these documents, below."
 msgstr "La mejor manera de confirmar quién es el propietario de su edificio es revisar los documentos oficiales de transacción inmobiliaria del mismo y buscar la firma del propietario. A continuación, le proporcionamos enlaces a dichos documentos."
 
-#: src/hooks/useCriteriaResults.tsx:475
+#: src/hooks/useCriteriaResults.tsx:478
 msgid "The building must have received its certificate of occupancy before 2009."
 msgstr "El edificio debe haber recibido su certificado de ocupación antes de 2009."
 
-#: src/hooks/useCriteriaResults.tsx:398
+#: src/hooks/useCriteriaResults.tsx:401
 msgid "The building must not be a condo, co-op, or other exempt building types."
 msgstr "El edificio no debe ser un condominio, una cooperativa u otro tipo de edificio exento."
 
-#: src/hooks/useCriteriaResults.tsx:526
-#: src/hooks/useCriteriaResults.tsx:578
-#: src/hooks/useCriteriaResults.tsx:601
-#: src/hooks/useCriteriaResults.tsx:656
+#: src/hooks/useCriteriaResults.tsx:529
+#: src/hooks/useCriteriaResults.tsx:581
+#: src/hooks/useCriteriaResults.tsx:604
+#: src/hooks/useCriteriaResults.tsx:659
 msgid "The building must not be part of NYCHA, PACT/RAD, or other subsidized housing."
 msgstr "El edificio no debe formar parte de NYCHA, PACT/RAD u otras viviendas subvencionadas."
 
@@ -1502,9 +1502,9 @@ msgstr "Ver todos los documentos en ACRIS"
 #: src/hooks/useCriteriaResults.tsx:235
 #: src/hooks/useCriteriaResults.tsx:317
 #: src/hooks/useCriteriaResults.tsx:322
-#: src/hooks/useCriteriaResults.tsx:448
-#: src/hooks/useCriteriaResults.tsx:497
-#: src/hooks/useCriteriaResults.tsx:519
+#: src/hooks/useCriteriaResults.tsx:451
+#: src/hooks/useCriteriaResults.tsx:500
+#: src/hooks/useCriteriaResults.tsx:522
 msgid "View source"
 msgstr "Ver fuente"
 
@@ -1632,19 +1632,28 @@ msgstr "Solo necesita encontrar el nombre o la firma del propietario de su edifi
 #~ msgid "You reported that {0} rent stabilized, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that{2} {3}If those sources are correct, then you may already have stronger tenant protections than Good Cause Eviction provides. {guideLink}"
 #~ msgstr "Usted informó que {0} tiene renta estabilizada, y estamos utilizando su respuesta como parte de nuestra evaluación de cobertura. Nota: las fuentes de datos disponibles públicamente indican que{2} {3}Si esas fuentes son correctas, es posible que ya cuente con protecciones para inquilinos más sólidas que las que ofrece Good Cause Eviction. {guideLink}"
 
-#: src/hooks/useCriteriaResults.tsx:377
-#~ msgid "You reported that you are not sure if your apartment is rent stabilized. {guideLink}"
-#~ msgstr "Usted informó que no está seguro de si su departamento tiene renta estabilizada. {guideLink}"
+#: src/hooks/useCriteriaResults.tsx:380
+msgid "You reported that you are not sure if your apartment is rent stabilized. {guideLink}"
+msgstr "Usted informó que no está seguro de si su departamento tiene renta estabilizada. {guideLink}"
 
-#: src/hooks/useCriteriaResults.tsx:375
-#~ msgid "You reported that your apartment is not rent stabilized."
-#~ msgstr "Usted informó que su departamento no tiene renta estabilizada."
+#: src/hooks/useCriteriaResults.tsx:351
+msgid "You reported that your apartment is not rent stabilized, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that all apartments in your building are registered as rent stabilized. {wowLink} If those sources are correct, then you may already have stronger tenant protections than Good Cause Eviction provides. {guideLink}"
+msgstr ""
+
+#. placeholder {0}: activeJ51 ? "421a" : "J51"
+#: src/hooks/useCriteriaResults.tsx:362
+msgid "You reported that your apartment is not rent stabilized, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building receives the {0} tax incentive, which means your apartment should be rent stabilized. {subsidyLink} If those sources are correct, then you may already have stronger tenant protections than Good Cause Eviction provides. {guideLink}"
+msgstr ""
+
+#: src/hooks/useCriteriaResults.tsx:374
+msgid "You reported that your apartment is not rent stabilized."
+msgstr "Usted informó que su departamento no tiene renta estabilizada."
 
 #: src/hooks/useCriteriaResults.tsx:345
 msgid "You reported that your apartment is rent stabilized."
 msgstr "Usted informó que su departamento tiene renta estabilizada."
 
-#: src/hooks/useCriteriaResults.tsx:609
+#: src/hooks/useCriteriaResults.tsx:612
 msgid "You reported that your building is not part of any subsidized housing programs, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building is part of NYCHA or PACT/RAD."
 msgstr "Usted informó que su edificio no forma parte de ningún programa de vivienda subsidiada, y estamos utilizando su respuesta como parte de nuestra evaluación de cobertura. Nota: las fuentes de datos disponibles públicamente indican que su edificio forma parte de NYCHA o PACT/RAD."
 
@@ -1652,7 +1661,7 @@ msgstr "Usted informó que su edificio no forma parte de ningún programa de viv
 #~ msgid "You reported that your building is not part of any subsidized housing programs, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building is part of NYCHA or PACT/RAD. {sourceLink} If those sources are correct, you may have existing tenant protections through NYCHA or PACT/RAD."
 #~ msgstr "You reported that your building is not part of any subsidized housing programs, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building is part of NYCHA or PACT/RAD. {sourceLink} If those sources are correct, you may have existing tenant protections through NYCHA or PACT/RAD."
 
-#: src/hooks/useCriteriaResults.tsx:556
+#: src/hooks/useCriteriaResults.tsx:559
 msgid "You reported that your building is not part of NYCHA, PACT/RAD, or other subsidized housing programs."
 msgstr "Usted informó que su edificio no forma parte de NYCHA, PACT/RAD ni otros programas de vivienda subsidiada."
 
@@ -1660,7 +1669,7 @@ msgstr "Usted informó que su edificio no forma parte de NYCHA, PACT/RAD ni otro
 #~ msgid "You reported that your building is not part of NYCHA, PACT/RAD, or other subsidized housing, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building {0} , which is considered subsidized housing. {sourceLink} If those sources are correct, you may have existing tenant protections through your building’s subsidy program."
 #~ msgstr "You reported that your building is not part of NYCHA, PACT/RAD, or other subsidized housing, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building {0} , which is considered subsidized housing. {sourceLink} If those sources are correct, you may have existing tenant protections through your building’s subsidy program."
 
-#: src/hooks/useCriteriaResults.tsx:664
+#: src/hooks/useCriteriaResults.tsx:667
 msgid "You reported that your building is not part of NYCHA, PACT/RAD, or other subsidized housing, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building <0/> , which is considered subsidized housing."
 msgstr "Usted informó que su edificio no forma parte de NYCHA, PACT/RAD ni de ningún otro programa de vivienda subsidiada, y estamos utilizando su respuesta como parte de nuestra evaluación de cobertura. Nota: las fuentes de datos disponibles públicamente indican que su edificio <0/>, que se considera vivienda subsidiada."
 
@@ -1672,16 +1681,16 @@ msgstr "Usted informó que su edificio no forma parte de NYCHA, PACT/RAD ni de n
 #~ msgid "You reported that your building is part of NYCHA or PACT/RAD, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building {0}, which is considered subsidized housing. {sourceLink} If those sources are correct, then your protections may be different than the protections of NYCHA or PACT/RAD."
 #~ msgstr "You reported that your building is part of NYCHA or PACT/RAD, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building {0}, which is considered subsidized housing. {sourceLink} If those sources are correct, then your protections may be different than the protections of NYCHA or PACT/RAD."
 
-#: src/hooks/useCriteriaResults.tsx:634
+#: src/hooks/useCriteriaResults.tsx:637
 msgid "You reported that your building is part of NYCHA or PACT/RAD, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building <0/>, which is considered subsidized housing. {sourceLink} If those sources are correct, then your protections may be different than the protections of NYCHA or PACT/RAD."
 msgstr "Usted informó que su edificio forma parte de NYCHA o PACT/RAD, y estamos utilizando su respuesta como parte de nuestra evaluación de cobertura. Nota: las fuentes de datos disponibles públicamente indican que su edificio <0/>, que se considera vivienda subsidiada. {sourceLink} Si esas fuentes son correctas, entonces sus protecciones pueden ser diferentes a las protecciones de NYCHA o PACT/RAD."
 
-#: src/hooks/useCriteriaResults.tsx:533
-#: src/hooks/useCriteriaResults.tsx:572
+#: src/hooks/useCriteriaResults.tsx:536
+#: src/hooks/useCriteriaResults.tsx:575
 msgid "You reported that your building is part of NYCHA or PACT/RAD."
 msgstr "Usted informó que su edificio forma parte de NYCHA o PACT/RAD."
 
-#: src/hooks/useCriteriaResults.tsx:586
+#: src/hooks/useCriteriaResults.tsx:589
 msgid "You reported that your building is subsidized, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building is part of NYCHA or PACT/RAD."
 msgstr "Usted informó que su edificio está subsidiado, y estamos utilizando su respuesta como parte de nuestra evaluación de cobertura. Nota: las fuentes de datos disponibles públicamente indican que su edificio forma parte de NYCHA o PACT/RAD."
 
@@ -1689,8 +1698,8 @@ msgstr "Usted informó que su edificio está subsidiado, y estamos utilizando su
 #~ msgid "You reported that your building is subsidized, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building is part of NYCHA or PACT/RAD. {sourceLink} If those sources are correct, then you may already have stronger tenant protections than other subsidized housing programs."
 #~ msgstr "You reported that your building is subsidized, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building is part of NYCHA or PACT/RAD. {sourceLink} If those sources are correct, then you may already have stronger tenant protections than other subsidized housing programs."
 
-#: src/hooks/useCriteriaResults.tsx:545
-#: src/hooks/useCriteriaResults.tsx:653
+#: src/hooks/useCriteriaResults.tsx:548
+#: src/hooks/useCriteriaResults.tsx:656
 msgid "You reported that your building is subsidized."
 msgstr "Usted informó que su edificio está subsidiado."
 
@@ -1749,7 +1758,7 @@ msgstr "Tu edificio tiene {unitsres, plural, one {# apartamentos} other {# apart
 msgid "Your building has ${0} apartments and you reported that your landlord does not live in the building."
 msgstr "Su edificio tiene ${0} apartamentos y usted ha informado de que su arrendador no vive en el edificio."
 
-#: src/hooks/useCriteriaResults.tsx:484
+#: src/hooks/useCriteriaResults.tsx:487
 msgid "Your building has no new recorded certificate of occupancy since 2009."
 msgstr "Su edificio no tiene ningún certificado de ocupación nuevo registrado desde 2009."
 
@@ -1765,7 +1774,7 @@ msgstr "Tu edificio solo tiene {pluralApartments}, pero"
 #~ msgid "your building receives the {0} tax incentive, which means your apartment should be rent stabilized."
 #~ msgstr "Su edificio recibe el incentivo fiscal « {0} », lo que significa que su departamento debería tener un alquiler estabilizado."
 
-#: src/hooks/useCriteriaResults.tsx:488
+#: src/hooks/useCriteriaResults.tsx:491
 msgid "Your building was issued a certificate of occupancy on {latestCoDateFormatted}."
 msgstr "Su edificio obtuvo un certificado de ocupación el {latestCoDateFormatted}."
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -1638,12 +1638,12 @@ msgstr "Usted informó que no está seguro de si su departamento tiene renta est
 
 #: src/hooks/useCriteriaResults.tsx:351
 msgid "You reported that your apartment is not rent stabilized, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that all apartments in your building are registered as rent stabilized. {wowLink} If those sources are correct, then you may already have stronger tenant protections than Good Cause Eviction provides. {guideLink}"
-msgstr ""
+msgstr "aaaaa {guideLink}"
 
 #. placeholder {0}: activeJ51 ? "421a" : "J51"
 #: src/hooks/useCriteriaResults.tsx:362
 msgid "You reported that your apartment is not rent stabilized, and we are using your answer as part of our coverage assessment. Note: publicly available data sources indicate that your building receives the {0} tax incentive, which means your apartment should be rent stabilized. {subsidyLink} If those sources are correct, then you may already have stronger tenant protections than Good Cause Eviction provides. {guideLink}"
-msgstr ""
+msgstr "bbbbb {guideLink}"
 
 #: src/hooks/useCriteriaResults.tsx:374
 msgid "You reported that your apartment is not rent stabilized."


### PR DESCRIPTION
We were having a strange problem with lingui where in the english version the entire section f copy was replaced with a few jumbled characters. The copy for the user value for rent stab in the criteria table was composed with a lot of conditional logic and embedded subsections ([example](https://github.com/JustFixNYC/gce-screener/pull/179/files#diff-10a4985cd6e1b058bf3a318b140493e4c5154bbed9feb2156f32f4414e091a5cL1626-R1628)), so this was probably breaking lingui's ability to piece together the strings properly. This PR refactors to simplify the logic for lingui and minimize embedded sections. 

For some reason the original problem was not happening in local dev, only on the demo/prod site, so on this branch I also manually edited the es/messages.po to add in new translations and it's showing up as intended on the preview deploy link (I then reverted those edits).