### PR TITLE
fix cpi typo in letter copy

### DIFF
--- a/src/Components/LetterBuilder/Letter/Letter.tsx
+++ b/src/Components/LetterBuilder/Letter/Letter.tsx
@@ -158,8 +158,8 @@ const LetterRightsList = () => {
             </ul>
             <p>
               <Trans>
-                For New York City, the CPI change is {CPI + 5}% as of{" "}
-                {_(CPI_EFFECTIVE_DATE)}, meaning increases above this level
+                For New York City, the CPI is {CPI}% as of{" "}
+                {_(CPI_EFFECTIVE_DATE)}, meaning increases above {CPI + 5}%
                 require justification under the statute.
               </Trans>
             </p>

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1019,11 +1019,15 @@ msgstr "For leases offered after {0}, landlords cannot increase rent more than {
 #~ msgid "For leases offered on or after {0}, landlords cannot increase rent more than {1}% without legitimate justification. You can use our <0>rent increase calculator</0> to learn more and determine if your landlord’s proposed rent exceeds the allowable rent increase amount."
 #~ msgstr "For leases offered on or after {0}, landlords cannot increase rent more than {1}% without legitimate justification. You can use our <0>rent increase calculator</0> to learn more and determine if your landlord’s proposed rent exceeds the allowable rent increase amount."
 
-#. placeholder {0}: CPI + 5
-#. placeholder {1}: _(CPI_EFFECTIVE_DATE)
 #: src/Components/LetterBuilder/Letter/Letter.tsx:160
-msgid "For New York City, the CPI change is {0}% as of {1}, meaning increases above this level require justification under the statute."
-msgstr "For New York City, the CPI change is {0}% as of {1}, meaning increases above this level require justification under the statute."
+#~ msgid "For New York City, the CPI change is {0}% as of {1}, meaning increases above this level require justification under the statute."
+#~ msgstr "For New York City, the CPI change is {0}% as of {1}, meaning increases above this level require justification under the statute."
+
+#. placeholder {0}: _(CPI_EFFECTIVE_DATE)
+#. placeholder {1}: CPI + 5
+#: src/Components/LetterBuilder/Letter/Letter.tsx:160
+msgid "For New York City, the CPI is {CPI}% as of {0}, meaning increases above {1}% require justification under the statute."
+msgstr "For New York City, the CPI is {CPI}% as of {0}, meaning increases above {1}% require justification under the statute."
 
 #: src/Components/KYRContent/KYRContent.tsx:752
 msgid "For rent-stabilized leases being renewed between October 1, 2024 and September 30, 2025 the legal rent may be increased at the following levels: for a one-year renewal there is a 2.75% increase, or for a two-year renewal there is a 5.25% increase."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -1024,11 +1024,15 @@ msgstr "Para los arrendamientos ofrecidos después del {0}, los arrendadores no 
 #~ msgid "For leases offered on or after {0}, landlords cannot increase rent more than {1}% without legitimate justification. You can use our <0>rent increase calculator</0> to learn more and determine if your landlord’s proposed rent exceeds the allowable rent increase amount."
 #~ msgstr "For leases offered on or after {0}, landlords cannot increase rent more than {1}% without legitimate justification. You can use our <0>rent increase calculator</0> to learn more and determine if your landlord’s proposed rent exceeds the allowable rent increase amount."
 
-#. placeholder {0}: CPI + 5
-#. placeholder {1}: _(CPI_EFFECTIVE_DATE)
 #: src/Components/LetterBuilder/Letter/Letter.tsx:160
-msgid "For New York City, the CPI change is {0}% as of {1}, meaning increases above this level require justification under the statute."
-msgstr "Para la ciudad de Nueva York, la variación del IPC es del {0} % a fecha de {1}, lo que significa que los aumentos por encima de este nivel requieren una justificación según la ley."
+#~ msgid "For New York City, the CPI change is {0}% as of {1}, meaning increases above this level require justification under the statute."
+#~ msgstr "Para la ciudad de Nueva York, la variación del IPC es del {0} % a fecha de {1}, lo que significa que los aumentos por encima de este nivel requieren una justificación según la ley."
+
+#. placeholder {0}: _(CPI_EFFECTIVE_DATE)
+#. placeholder {1}: CPI + 5
+#: src/Components/LetterBuilder/Letter/Letter.tsx:160
+msgid "For New York City, the CPI is {CPI}% as of {0}, meaning increases above {1}% require justification under the statute."
+msgstr ""
 
 #: src/Components/KYRContent/KYRContent.tsx:752
 msgid "For rent-stabilized leases being renewed between October 1, 2024 and September 30, 2025 the legal rent may be increased at the following levels: for a one-year renewal there is a 2.75% increase, or for a two-year renewal there is a 5.25% increase."
@@ -4540,4 +4544,3 @@ msgstr "Se requiere el código postal para la carta"
 #: src/types/LetterFormTypes.ts:27
 #~ msgid "ZIP Code must be either 5-digit number or 5-digits with hyphen and 4 additional digits."
 #~ msgstr "ZIP Code must be either 5-digit number or 5-digits with hyphen and 4 additional digits."
-


### PR DESCRIPTION
we were alerted to a typo in the letter copy explaining the CPI vs CPI+5% reasonable rent increase standard. 